### PR TITLE
fix: update Qwen 3.5 model tags to correct library names

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ So everyone builds a **proxy** to translate between them. That proxy adds latenc
 | Your Mac | RAM | What You Can Run |
 |----------|-----|-------------------|
 | M1/M2/M3/M4 (base) | 8-16 GB | 🟡 Small models (4B) |
-| M1/M2/M3/M4 Pro | 18-36 GB | 🟠 Medium models (32B) |
+| M1/M2/M3/M4 Pro | 18-36 GB | 🟠 Medium models (35B) |
 | M2/M3/M4/M5 Max | 64-128 GB | 🟢 **Large models (122B)** |
 | M2/M3/M4 Ultra | 128-192 GB | 🔵 Multiple large models |
 

--- a/setup.sh
+++ b/setup.sh
@@ -50,8 +50,8 @@ if [ "$MEM_GB" -ge 96 ]; then
   MODEL="qwen3.5:122b"
   MODEL_DESC="122B (81 GB) — full power"
 elif [ "$MEM_GB" -ge 32 ]; then
-  MODEL="qwen3.5:32b"
-  MODEL_DESC="32B (20 GB) — great coding"
+  MODEL="qwen3.5:35b"
+  MODEL_DESC="35B (20 GB) — great coding"
 else
   MODEL="qwen3.5:4b"
   MODEL_DESC="4B (3.4 GB) — lightweight"


### PR DESCRIPTION
The Qwen 3.5 series on Ollama uses '35b' instead of '32b' for the medium parameter model. This PR updates setup.sh and README.md to use the correct tags and RAM references.