### PR TITLE
fix(launchers): align launcher configs with current Claude Code behavior

### DIFF
--- a/launchers/Browser Agent.command
+++ b/launchers/Browser Agent.command
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 # Brave Browser Agent — Direct MLX + Chrome DevTools Protocol (no Claude Code)
 # Double-click to launch
 #
@@ -8,11 +9,51 @@ MLX_PYTHON="$HOME/.local/mlx-server/bin/python3"
 MLX_SERVER="$HOME/.local/mlx-native-server/server.py"
 AGENT="$HOME/.local/browser-agent/agent.py"
 MODEL_NAME="${MLX_MODEL_LABEL:-Gemma 4 31B}"
+MLX_MODEL_DEFAULT="${MLX_MODEL:-divinetribe/gemma-4-31b-it-abliterated-4bit-mlx}"
+MLX_KV_BITS_DEFAULT="${MLX_KV_BITS:-0}"
 
-# Start MLX server if not running
+cleanup() {
+  if [ "${STARTED_MLX_SERVER:-0}" -eq 1 ] && [ -n "${MLX_SERVER_PID:-}" ]; then
+    if kill -0 "$MLX_SERVER_PID" >/dev/null 2>&1; then
+      kill "$MLX_SERVER_PID" >/dev/null 2>&1 || true
+      wait "$MLX_SERVER_PID" 2>/dev/null || true
+    fi
+  fi
+}
+
+trap cleanup EXIT INT TERM
+
+if [ ! -f "$MLX_PYTHON" ]; then
+  echo "  ERROR: MLX Python not found at $MLX_PYTHON"
+  exit 1
+fi
+
+if [ ! -f "$MLX_SERVER" ]; then
+  echo "  ERROR: MLX server not found at $MLX_SERVER"
+  exit 1
+fi
+
+if [ ! -f "$AGENT" ]; then
+  echo "  ERROR: Browser agent not found at $AGENT"
+  exit 1
+fi
+
+if lsof -i :4000 >/dev/null 2>&1; then
+  echo "  Restarting MLX server in browser mode..."
+  pkill -f "mlx-native-server/server.py" 2>/dev/null || true
+  for i in $(seq 1 20); do
+    if ! lsof -i :4000 >/dev/null 2>&1; then
+      break
+    fi
+    sleep 1
+  done
+fi
+
 if ! lsof -i :4000 >/dev/null 2>&1; then
   echo "  Loading $MODEL_NAME..."
-  MLX_BROWSER_MODE=1 "$MLX_PYTHON" "$MLX_SERVER" >/tmp/mlx-server.log 2>&1 &
+  MLX_BROWSER_MODE=1 MLX_KV_BITS="$MLX_KV_BITS_DEFAULT" MLX_MODEL="$MLX_MODEL_DEFAULT" "$MLX_PYTHON" "$MLX_SERVER" >/tmp/mlx-server.log 2>&1 &
+  MLX_SERVER_PID=$!
+  STARTED_MLX_SERVER=1
   while ! curl -s http://localhost:4000/health 2>/dev/null | grep -q "ok"; do sleep 2; done
 fi
 
@@ -66,4 +107,5 @@ echo "  ║  iframes + Shadow DOM · 100% local            ║"
 echo "  ╚═══════════════════════════════════════════════╝"
 echo ""
 
-exec "$MLX_PYTHON" "$AGENT"
+"$MLX_PYTHON" "$AGENT"
+exit $?

--- a/launchers/Claude Local Fast.command
+++ b/launchers/Claude Local Fast.command
@@ -1,19 +1,19 @@
 #!/bin/bash
 set -euo pipefail
-# Claude Code — Local AI (runs on your Mac, no cloud)
-# Double-click to launch
-# MLX Native Server — direct Anthropic API, no proxy needed
-#
-# Override the model with: MLX_MODEL=mlx-community/<model-id>
+# Claude Code — Local AI (FAST mode)
+# Speed-first launcher:
+# - --bare (skip skills/plugins/hooks discovery)
+# - constrained built-in tool set
+# - Gemma 4 31B default model
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/claude-local-common.sh"
 
 CLAUDE_BIN="${CLAUDE_BIN:-$HOME/.local/bin/claude}"
-MLX_SERVER="$HOME/.local/mlx-native-server/server.py"
-MLX_PYTHON="$HOME/.local/mlx-server/bin/python3"
-MODEL_NAME="${MLX_MODEL_LABEL:-Qwen 3.5 122B}"
-MLX_MODEL_DEFAULT="mlx-community/Qwen3.5-122B-A10B-4bit"
+MLX_SERVER="${MLX_SERVER:-$HOME/.local/mlx-native-server/server.py}"
+MLX_PYTHON="${MLX_PYTHON:-$HOME/.local/mlx-server/bin/python3}"
+MODEL_NAME="${MLX_MODEL_LABEL:-Gemma 4 31B (Fast)}"
+MLX_MODEL_DEFAULT="divinetribe/gemma-4-31b-it-abliterated-4bit-mlx"
 REQUESTED_MODEL="${MLX_MODEL:-$MLX_MODEL_DEFAULT}"
 MCP_CONFIG="$(build_user_mcp_config)"
 
@@ -32,18 +32,17 @@ ensure_mlx_server "$REQUESTED_MODEL" "  Loading $MODEL_NAME on MLX..."
 
 clear
 echo ""
-echo "  → Claude Code with LOCAL AI ($MODEL_NAME)"
-echo "  → MLX Native: zero proxy, zero cloud, zero API fees"
-echo "  → Running 100% on your Apple Silicon GPU"
+echo "  -> Claude Code LOCAL FAST mode"
+echo "  -> $MODEL_NAME"
+echo "  -> bare mode + minimal tools for lower latency"
 echo ""
 
-# Preserve normal Claude Code features like skills and hooks.
-# MCP servers are extracted from the current Claude settings into a
-# schema-valid temp file for this session.
 ANTHROPIC_BASE_URL=http://localhost:4000 \
 ANTHROPIC_API_KEY=sk-local \
 "$CLAUDE_BIN" --model claude-sonnet-4-6 \
   --permission-mode auto \
+  --bare \
+  --tools "Bash,Read,Edit,Write,Glob,Grep,LS,MultiEdit" \
   --append-system-prompt-file "$HOME/.claude/CLAUDE.md" \
   --mcp-config "$MCP_CONFIG"
 exit $?

--- a/launchers/Gemma 4 Code.command
+++ b/launchers/Gemma 4 Code.command
@@ -1,26 +1,34 @@
 #!/bin/bash
+set -euo pipefail
 # Gemma 4 Code — Claude Code on Gemma 4 31B Abliterated (4-bit MLX)
 # Double-click to launch
 #
 # THE QUICK ONE — ~15 tok/s, ~18 GB RAM, abliterated, instruction-tuned.
 # Best balance of speed and quality for daily coding.
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/claude-local-common.sh"
+
 CLAUDE_BIN="${CLAUDE_BIN:-$HOME/.local/bin/claude}"
 MLX_SERVER="$HOME/.local/mlx-native-server/server.py"
 MLX_PYTHON="$HOME/.local/mlx-server/bin/python3"
+MCP_CONFIG="$(build_user_mcp_config)"
+
+cleanup() {
+  cleanup_mlx_server
+  rm -f "$MCP_CONFIG"
+}
+
+trap cleanup EXIT INT TERM
+
+require_file "$CLAUDE_BIN" "Claude Code CLI"
+require_file "$MLX_SERVER" "MLX server"
+require_file "$MLX_PYTHON" "MLX Python"
 
 # Override with MLX_MODEL=<your-path-or-hf-id>
 MLX_MODEL_DEFAULT="divinetribe/gemma-4-31b-it-abliterated-4bit-mlx"
 
-# Start MLX server if not running (or if a different model is loaded)
-if ! lsof -i :4000 >/dev/null 2>&1; then
-  MLX_MODEL="${MLX_MODEL:-$MLX_MODEL_DEFAULT}" \
-  "$MLX_PYTHON" "$MLX_SERVER" >/tmp/mlx-server.log 2>&1 &
-  echo "  Loading Gemma 4 31B Abliterated on MLX (~15 tok/s, 4-bit)..."
-  while ! curl -s http://localhost:4000/health 2>/dev/null | grep -q "ok"; do
-    sleep 2
-  done
-fi
+ensure_mlx_server "${MLX_MODEL:-$MLX_MODEL_DEFAULT}" "  Loading Gemma 4 31B Abliterated on MLX (~15 tok/s, 4-bit)..."
 
 clear
 echo ""
@@ -32,8 +40,8 @@ echo ""
 ANTHROPIC_BASE_URL=http://localhost:4000 \
 ANTHROPIC_API_KEY=sk-local \
 CLAUDE_SESSION_LABEL="Gemma 4 · Local" \
-exec "$CLAUDE_BIN" --model claude-sonnet-4-6 \
+"$CLAUDE_BIN" --model claude-sonnet-4-6 \
   --permission-mode auto \
-  --bare \
   --append-system-prompt-file "$HOME/.claude/CLAUDE.md" \
-  --mcp-config "$HOME/.claude.json"
+  --mcp-config "$MCP_CONFIG"
+exit $?

--- a/launchers/Llama 70B.command
+++ b/launchers/Llama 70B.command
@@ -1,28 +1,36 @@
 #!/bin/bash
+set -euo pipefail
 # Llama 70B — Claude Code on Llama 3.3 70B Abliterated (8-bit MLX)
 # Double-click to launch
 #
 # THE WISE ONE — ~7 tok/s, ~70 GB RAM, full 8-bit precision, abliterated.
 # Slower but the most capable reasoning in the lineup. Needs 96+ GB unified memory.
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/claude-local-common.sh"
+
 CLAUDE_BIN="${CLAUDE_BIN:-$HOME/.local/bin/claude}"
 MLX_SERVER="$HOME/.local/mlx-native-server/server.py"
 MLX_PYTHON="$HOME/.local/mlx-server/bin/python3"
+MCP_CONFIG="$(build_user_mcp_config)"
+
+cleanup() {
+  cleanup_mlx_server
+  rm -f "$MCP_CONFIG"
+}
+
+trap cleanup EXIT INT TERM
+
+require_file "$CLAUDE_BIN" "Claude Code CLI"
+require_file "$MLX_SERVER" "MLX server"
+require_file "$MLX_PYTHON" "MLX Python"
 
 # Default points at our own abliterated MLX upload:
 #   https://huggingface.co/divinetribe/Llama-3.3-70B-Instruct-abliterated-8bit-mlx
 # Override with MLX_MODEL=<your-path-or-hf-id>
 MLX_MODEL_DEFAULT="divinetribe/Llama-3.3-70B-Instruct-abliterated-8bit-mlx"
 
-# Start MLX server if not running
-if ! lsof -i :4000 >/dev/null 2>&1; then
-  MLX_MODEL="${MLX_MODEL:-$MLX_MODEL_DEFAULT}" \
-  "$MLX_PYTHON" "$MLX_SERVER" >/tmp/mlx-server.log 2>&1 &
-  echo "  Loading Llama 3.3 70B Abliterated on MLX (~7 tok/s, 8-bit full precision)..."
-  while ! curl -s http://localhost:4000/health 2>/dev/null | grep -q "ok"; do
-    sleep 2
-  done
-fi
+ensure_mlx_server "${MLX_MODEL:-$MLX_MODEL_DEFAULT}" "  Loading Llama 3.3 70B Abliterated on MLX (~7 tok/s, 8-bit full precision)..."
 
 clear
 echo ""
@@ -34,8 +42,8 @@ echo ""
 ANTHROPIC_BASE_URL=http://localhost:4000 \
 ANTHROPIC_API_KEY=sk-local \
 CLAUDE_SESSION_LABEL="Llama 70B · Local" \
-exec "$CLAUDE_BIN" --model claude-sonnet-4-6 \
+"$CLAUDE_BIN" --model claude-sonnet-4-6 \
   --permission-mode auto \
-  --bare \
   --append-system-prompt-file "$HOME/.claude/CLAUDE.md" \
-  --mcp-config "$HOME/.claude.json"
+  --mcp-config "$MCP_CONFIG"
+exit $?

--- a/launchers/Narrative Gemma.command
+++ b/launchers/Narrative Gemma.command
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 # Narrative Gemma — Local AI Claude Code with auto-narration
 # Double-click to launch
 #
@@ -11,38 +12,45 @@
 #   your speakers. Stub it with `say "$@"` (macOS built-in) if you don't
 #   have a fancier voice setup. The CLAUDE.md persona expects this binary.
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/claude-local-common.sh"
+
 CLAUDE_BIN="${CLAUDE_BIN:-$HOME/.local/bin/claude}"
 MLX_SERVER="$HOME/.local/mlx-native-server/server.py"
 MLX_PYTHON="$HOME/.local/mlx-server/bin/python3"
-PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)/NarrativeGemma"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)/NarrativeGemma"
 COMBINED_PROMPT="/tmp/narrative_gemma_combined_prompt.md"
+MCP_CONFIG="$(build_user_mcp_config)"
+
+cleanup() {
+  cleanup_mlx_server
+  rm -f "$MCP_CONFIG" "$COMBINED_PROMPT"
+}
+
+trap cleanup EXIT INT TERM
+
+require_file "$CLAUDE_BIN" "Claude Code CLI"
+require_file "$MLX_SERVER" "MLX server"
+require_file "$MLX_PYTHON" "MLX Python"
+require_file "$PROJECT_DIR/CLAUDE.md" "NarrativeGemma CLAUDE.md"
 
 # Override the model with: MLX_MODEL=<your-path-or-hf-id>
 MLX_MODEL_DEFAULT="divinetribe/gemma-4-31b-it-abliterated-4bit-mlx"
 
 # ── Build combined system prompt ──────────────────────────────────────
-# --bare disables auto-memory, so we hand-stitch the narration rules into
-# a file that the patched MLX server appends to its mode-specific prompt.
+# Build the narration prompt into a temporary file so we can append it
+# explicitly while keeping normal Claude Code features enabled.
 {
   cat "$PROJECT_DIR/CLAUDE.md"
 } > "$COMBINED_PROMPT"
 
-# Always restart the MLX server in narrative mode so it picks up the
-# MLX_APPEND_SYSTEM_PROMPT_FILE env var. If we left a stale server
-# running from another launcher, narration rules wouldn't be loaded.
-if curl -sf http://localhost:4000/health >/dev/null 2>&1; then
-  echo "  Stopping existing MLX server to load narration rules..."
-  pkill -f "mlx-native-server/server.py" 2>/dev/null
-  sleep 2
+if lsof -i :4000 >/dev/null 2>&1; then
+  echo "  Restarting MLX server to load narration rules..."
+  pkill -f "mlx-native-server/server.py" 2>/dev/null || true
+  wait_for_mlx_server_shutdown || true
 fi
 
-export MLX_APPEND_SYSTEM_PROMPT_FILE="$COMBINED_PROMPT"
-MLX_MODEL="${MLX_MODEL:-$MLX_MODEL_DEFAULT}" \
-  "$MLX_PYTHON" "$MLX_SERVER" >/tmp/mlx-server.log 2>&1 &
-echo "  Loading Gemma 4 31B Abliterated with narration rules..."
-while ! curl -s http://localhost:4000/health 2>/dev/null | grep -q "ok"; do
-  sleep 2
-done
+ensure_mlx_server "${MLX_MODEL:-$MLX_MODEL_DEFAULT}" "  Loading Gemma 4 31B Abliterated with narration rules..." "MLX_APPEND_SYSTEM_PROMPT_FILE=$COMBINED_PROMPT"
 
 clear
 echo ""
@@ -61,8 +69,8 @@ cd "$PROJECT_DIR" || exit 1
 ANTHROPIC_BASE_URL=http://localhost:4000 \
 ANTHROPIC_API_KEY=sk-local \
 CLAUDE_SESSION_LABEL="Narrative Gemma · Local" \
-exec "$CLAUDE_BIN" --model claude-sonnet-4-6 \
+"$CLAUDE_BIN" --model claude-sonnet-4-6 \
   --permission-mode auto \
-  --bare \
   --append-system-prompt-file "$COMBINED_PROMPT" \
-  --mcp-config "$HOME/.claude.json"
+  --mcp-config "$MCP_CONFIG"
+exit $?

--- a/launchers/lib/claude-local-common.sh
+++ b/launchers/lib/claude-local-common.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+
+STARTED_MLX_SERVER=0
+MLX_SERVER_PID=""
+
+require_file() {
+  local path="$1"
+  local label="$2"
+
+  if [ ! -f "$path" ]; then
+    echo "  ERROR: $label not found at $path"
+    exit 1
+  fi
+}
+
+build_user_mcp_config() {
+  local output_path
+  output_path="$(mktemp -t claude-local-mcp).json"
+
+  python3 - "$output_path" <<'PY'
+import json
+import pathlib
+import sys
+
+output_path = pathlib.Path(sys.argv[1])
+settings_paths = [
+    pathlib.Path.home() / ".claude" / "settings.json",
+    pathlib.Path.home() / ".claude" / "settings.local.json",
+]
+
+merged = {}
+for path in settings_paths:
+    if not path.exists():
+        continue
+
+    try:
+        data = json.loads(path.read_text())
+    except Exception:
+        continue
+
+    servers = data.get("mcpServers")
+    if isinstance(servers, dict):
+        merged.update(servers)
+
+output_path.write_text(json.dumps({"mcpServers": merged}, indent=2))
+PY
+
+  echo "$output_path"
+}
+
+get_running_mlx_model() {
+  curl -sf http://127.0.0.1:4000/health 2>/dev/null | python3 -c '
+import json
+import sys
+
+try:
+    payload = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+
+model = payload.get("model", "")
+if model:
+    print(model)
+'
+}
+
+get_running_mlx_kv_bits() {
+  curl -sf http://127.0.0.1:4000/health 2>/dev/null | python3 -c '
+import json
+import sys
+
+try:
+    payload = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+
+kv_bits = payload.get("kv_bits")
+if kv_bits is not None:
+    print(kv_bits)
+'
+}
+
+wait_for_mlx_server() {
+  local attempts="${1:-60}"
+  local delay="${2:-2}"
+  local i
+
+  for i in $(seq 1 "$attempts"); do
+    if curl -sf http://127.0.0.1:4000/health >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep "$delay"
+  done
+
+  echo "  ERROR: Timed out waiting for MLX server on port 4000"
+  return 1
+}
+
+wait_for_mlx_server_shutdown() {
+  local attempts="${1:-20}"
+  local delay="${2:-1}"
+  local i
+
+  for i in $(seq 1 "$attempts"); do
+    if ! lsof -i :4000 >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep "$delay"
+  done
+
+  echo "  WARNING: MLX server is still listening on port 4000"
+  return 1
+}
+
+ensure_mlx_server() {
+  local desired_model="$1"
+  local loading_message="$2"
+  shift 2
+  local -a env_args=("$@")
+  local running_model=""
+  local running_kv_bits=""
+  local desired_kv_bits="${MLX_KV_BITS:-0}"
+
+  if lsof -i :4000 >/dev/null 2>&1; then
+    running_model="$(get_running_mlx_model || true)"
+    running_kv_bits="$(get_running_mlx_kv_bits || true)"
+    if [ -n "$desired_model" ] && [ "$running_model" != "$desired_model" ]; then
+      echo "  Restarting MLX server for requested model..."
+      pkill -f "mlx-native-server/server.py" 2>/dev/null || true
+      wait_for_mlx_server_shutdown || true
+    elif [ -z "$running_kv_bits" ] || [ "$running_kv_bits" != "$desired_kv_bits" ]; then
+      echo "  Restarting MLX server to apply KV cache setting (MLX_KV_BITS=$desired_kv_bits)..."
+      pkill -f "mlx-native-server/server.py" 2>/dev/null || true
+      wait_for_mlx_server_shutdown || true
+    fi
+  fi
+
+  if ! lsof -i :4000 >/dev/null 2>&1; then
+    echo "$loading_message"
+    if [ ${#env_args[@]} -gt 0 ]; then
+      env "${env_args[@]}" MLX_KV_BITS="$desired_kv_bits" MLX_MODEL="$desired_model" "$MLX_PYTHON" "$MLX_SERVER" >/tmp/mlx-server.log 2>&1 &
+    else
+      MLX_KV_BITS="$desired_kv_bits" MLX_MODEL="$desired_model" "$MLX_PYTHON" "$MLX_SERVER" >/tmp/mlx-server.log 2>&1 &
+    fi
+    MLX_SERVER_PID=$!
+    STARTED_MLX_SERVER=1
+    wait_for_mlx_server
+  fi
+}
+
+cleanup_mlx_server() {
+  if [ "${STARTED_MLX_SERVER:-0}" -eq 1 ] && [ -n "${MLX_SERVER_PID:-}" ]; then
+    if kill -0 "$MLX_SERVER_PID" >/dev/null 2>&1; then
+      kill "$MLX_SERVER_PID" >/dev/null 2>&1 || true
+      wait "$MLX_SERVER_PID" 2>/dev/null || true
+    fi
+  fi
+}

--- a/setup.sh
+++ b/setup.sh
@@ -100,21 +100,34 @@ if [ ! -f "$CLAUDE_BIN" ]; then
   CLAUDE_BIN="\$HOME/.local/bin/claude"
 fi
 
+LAUNCHER_LIB="$SCRIPT_DIR/launchers/lib/claude-local-common.sh"
 LAUNCHER="$HOME/Desktop/Claude Local.command"
 cat > "$LAUNCHER" <<LAUNCH
 #!/bin/bash
+set -euo pipefail
 # Claude Code — Local AI ($MODEL_LABEL)
 CLAUDE_BIN="$CLAUDE_BIN"
 MLX_PYTHON="$MLX_VENV/bin/python3"
 MLX_SERVER="$SERVER_DIR/server.py"
+MLX_MODEL_DEFAULT="$MODEL_ID"
+LAUNCHER_LIB="$LAUNCHER_LIB"
 
-if ! lsof -i :4000 >/dev/null 2>&1; then
-  MLX_MODEL="$MODEL_ID" "\$MLX_PYTHON" "\$MLX_SERVER" >/tmp/mlx-server.log 2>&1 &
-  echo "  Loading $MODEL_LABEL on MLX..."
-  while ! curl -s http://localhost:4000/health 2>/dev/null | grep -q "ok"; do
-    sleep 2
-  done
-fi
+source "\$LAUNCHER_LIB"
+
+MCP_CONFIG="\$(build_user_mcp_config)"
+
+cleanup() {
+  cleanup_mlx_server
+  rm -f "\$MCP_CONFIG"
+}
+
+trap cleanup EXIT INT TERM
+
+require_file "\$CLAUDE_BIN" "Claude Code CLI"
+require_file "\$MLX_PYTHON" "MLX Python"
+require_file "\$MLX_SERVER" "MLX server"
+
+ensure_mlx_server "\${MLX_MODEL:-\$MLX_MODEL_DEFAULT}" "  Loading $MODEL_LABEL on MLX..."
 
 clear
 echo ""
@@ -125,7 +138,11 @@ echo ""
 
 ANTHROPIC_BASE_URL=http://localhost:4000 \\
 ANTHROPIC_API_KEY=sk-local \\
-exec "\$CLAUDE_BIN" --model claude-sonnet-4-6
+"\$CLAUDE_BIN" --model claude-sonnet-4-6 \\
+  --permission-mode auto \\
+  --append-system-prompt-file "\$HOME/.claude/CLAUDE.md" \\
+  --mcp-config "\$MCP_CONFIG"
+exit \$?
 LAUNCH
 
 chmod +x "$LAUNCHER"


### PR DESCRIPTION
## Summary
- replace invalid MCP config wiring from ~/.claude.json with schema-valid mcpServers extraction from Claude settings
- remove --bare from standard launchers so skills and hooks load normally
- add a dedicated fast launcher (Claude Local Fast.command) that intentionally uses --bare plus minimal tools
- add launcher robustness: prerequisite file checks, model-aware server restart, and cleanup for launcher-started MLX processes
- update setup.sh generated desktop launcher to use the same modern launcher behavior

## Why
Current launchers can fail on modern Claude Code builds due to invalid MCP config usage, and can unintentionally disable skills via --bare. This change makes defaults safer and more predictable while keeping a speed-focused mode available.