### PR TITLE
Fix Gemma inference crash — auto-disable KV quantization

### DIFF
--- a/proxy/server.py
+++ b/proxy/server.py
@@ -56,13 +56,21 @@ def log(msg):
 # ─── Model Loading ───────────────────────────────────────────────────────────
 
 def load_model():
-    global model, tokenizer
+    global model, tokenizer, KV_BITS
     log(f"Loading model: {MODEL_PATH}")
     t0 = time.time()
     model, tokenizer = load(MODEL_PATH)
     mx.eval(model.parameters())
     elapsed = time.time() - t0
     log(f"Model loaded in {elapsed:.1f}s")
+
+    # Gemma uses sliding-window attention → RotatingKVCache, which mlx-lm
+    # can't quantize yet ("RotatingKVCache Quantization NYI"). Auto-disable
+    # KV quantization for Gemma so inference doesn't 500 on the first call.
+    if KV_BITS and "gemma" in MODEL_PATH.lower():
+        log("Gemma detected: disabling KV cache quantization (RotatingKVCache NYI)")
+        KV_BITS = 0
+
     log(f"KV cache quantization: {KV_BITS}-bit" if KV_BITS else "KV cache: full precision")
 
 


### PR DESCRIPTION
## Summary
- The default Gemma launcher currently 500s on the first inference call with `{"error":{"type":"server_error","message":"RotatingKVCache Quantization NYI"}}`.
- Root cause: Gemma uses sliding-window attention, so `mlx-lm` builds a `RotatingKVCache`. `mlx-lm` does not yet implement quantization for that cache type, but `proxy/server.py` defaults to `MLX_KV_BITS=8` and passes `kv_bits`/`quantized_kv_start` into `stream_generate` for every model.
- Fix: in `load_model()`, detect `"gemma"` in `MODEL_PATH` and force `KV_BITS = 0` for Gemma only. Llama 3.3 70B and Qwen keep the existing 8-bit KV quantization.

## Reproduction (before the fix)
```
bash scripts/start-mlx-server.sh   # loads divinetribe/gemma-4-31b-it-abliterated-4bit-mlx
# then any /v1/messages call →
# 500 {"error":{"type":"server_error","message":"RotatingKVCache Quantization NYI"}}
```

## After the fix
Startup log for Gemma now shows:
```
Gemma detected: disabling KV cache quantization (RotatingKVCache NYI)
KV cache: full precision
```
Llama/Qwen startup logs are unchanged (`KV cache quantization: 8-bit`).

## Test plan
- [x] `Gemma 4 Code.command` launcher → model loads, `/v1/messages` returns a normal response instead of 500
- [ ] `Llama 70B.command` launcher → still logs `KV cache quantization: 8-bit` (behavior unchanged)
- [ ] `Narrative Gemma.command` launcher → same fix applies, narration flow works

## Notes
- The detection is a simple substring check on `MODEL_PATH` (e.g. `divinetribe/gemma-4-31b-it-abliterated-4bit-mlx`, `mlx-community/gemma-*`). Happy to switch to a config-based check (`model.args.model_type`) if you'd prefer — the substring approach was the smallest diff that matched the existing style of the file.
- Users who want to force KV quant on Gemma anyway can always set `MLX_KV_BITS=0` themselves; this change only protects the default path.