### PR TITLE
FUNDING: enable GitHub Sponsors (nicedreamzapp approved)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,5 @@
-# Matt: to enable GitHub Sponsors, go to https://github.com/sponsors/accounts,
-# set up your Sponsors profile, then uncomment the next line.
-# github: nicedreamzapp
+# GitHub Sponsors (primary) — 💖 button on every repo with this file
+github: nicedreamzapp
 
-# Safe default — points at the existing nicedreamzwholesale software page.
+# Fallback / secondary — custom link to Nice Dreamz software page
 custom: ['https://nicedreamzwholesale.com/software/']


### PR DESCRIPTION
## What this does

One-line config change: uncomment the `github: nicedreamzapp` entry in `.github/FUNDING.yml` now that the Sponsors account is approved and payouts are active.

## Result

The 💖 Sponsor button will appear on every repo with this FUNDING.yml (including this one) alongside the existing custom link.

## Test plan

- [ ] After merge, confirm Sponsor button shows up on https://github.com/nicedreamzapp/claude-code-local
- [ ] Click the button — should route to https://github.com/sponsors/nicedreamzapp
- [ ] Custom link to nicedreamzwholesale.com/software also still shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)