### PR TITLE
Mac base/Pro 16 GB support: Qwen 2.5 14B, ChatML stop markers, <tools> parser, offline leak fix

### DIFF
--- a/docs/MAC-BASE-SETUP.md
+++ b/docs/MAC-BASE-SETUP.md
@@ -6,13 +6,14 @@ de memoria unificada** - hardware abaixo do alvo original do projeto
 (M Max / Ultra com 64-128 GB).
 
 A documentacao oficial do repositorio assume Mac Max/Ultra. Em hardware
-mais modesto, cinco problemas reproduziveis aparecem em sequencia:
+mais modesto, seis problemas reproduziveis aparecem em sequencia:
 
 1. Tela de selecao de login do Claude Code mesmo com `ANTHROPIC_API_KEY` setado
 2. Vazamento de tokens internos do modelo (`<|im_end|>`, `<|endoftext|>`, ...) na resposta
 3. Respostas vazias ("(No output)") em todas as mensagens
 4. Tool-calls do Qwen 2.5 nao reconhecidos pelo parser do servidor
 5. Claude Code chama `api.anthropic.com` no startup mesmo com `ANTHROPIC_BASE_URL` setado (vazamento de "100% offline")
+6. **Tools nunca executam:** Claude Code descarta toda resposta com `tool_use` porque o servidor responde JSON unico em vez de `text/event-stream`
 
 Este guia explica a causa de cada um e a correcao aplicada nesta branch.
 
@@ -293,6 +294,112 @@ Servidor MLX (`/tmp/mlx-server.log`):
 > Observacao adicional: em modo `--print`, e necessario fechar
 > o stdin com `</dev/null`, caso contrario o claude trava esperando
 > input mesmo com o prompt passado como argumento.
+
+---
+
+## 6. Bug critico do modo agentico - Claude Code descarta tool_use sem SSE
+
+Esse foi o problema mais dificil de diagnosticar e o que finalmente
+destravou o modo agentico em 16 GB.
+
+### Sintoma
+
+Em sessoes com tools:
+
+```bash
+claude "Use Bash para criar hello.txt com 'oi'" --print --dangerously-skip-permissions
+```
+
+Saida do claude: `(No output)`. Nenhum arquivo criado.
+
+No log do servidor MLX o que se ve eh:
+
+```
+POST /v1/messages tools=22
+  ← OK (68 tok) [tool_use: Bash]
+POST /v1/messages tools=22         ← Claude Code repete a MESMA request
+  DEBUG msg trail: [user] ['text','text','text']   ← sem assistant nem tool_result!
+  ← OK (15 tok) (No output)
+```
+
+Ou seja: o servidor gera o `tool_use` Bash corretamente, com `id`,
+`name`, `input.command` e `stop_reason: "tool_use"` validos. **Mas o
+Claude Code descarta a resposta inteira** e refaz a request original
+sem incluir o `assistant.tool_use` nem o `user.tool_result`. Por isso
+o num_turns reportado pelo CLI eh `1`: do ponto de vista dele, a
+primeira chamada nem aconteceu.
+
+### Causa
+
+Claude Code 2.1 envia `stream: true` em **toda** request que tem tools
+no body. Quando recebe `Content-Type: application/json` em vez de
+`text/event-stream`, ele descarta silenciosamente, retenta uma vez
+sem o tool_use no historico, e exibe `(No output)`.
+
+O `proxy/server.py` original ignorava o campo `stream` e sempre
+respondia com JSON unico via `send_json`. Para chat puro isso
+funciona porque a resposta cabe em um delta. Para tool_use, nao.
+
+### Correcao
+
+Implementar a sequencia de eventos SSE da Messages API da Anthropic
+no servidor (`send_anthropic_stream`):
+
+```
+event: message_start         <- com id/model/role
+event: content_block_start   <- por bloco
+event: content_block_delta   <- text_delta para texto, input_json_delta para tools
+event: content_block_stop
+event: message_delta         <- com stop_reason
+event: message_stop
+```
+
+E rotear:
+
+```python
+if body.get("stream"):
+    send_anthropic_stream(self, result)
+else:
+    send_json(self, 200, result)
+```
+
+Detalhe critico: o header `Connection` precisa ser `close` (nao
+`keep-alive`). Como o servidor gera a resposta inteira antes de
+"streamar" (replay de eventos), nao tem mais nada para mandar. Com
+`keep-alive` o cliente fica esperando indefinidamente.
+
+### Validacao
+
+Apos a fix, sessao agentica completa funciona:
+
+```bash
+ANTHROPIC_BASE_URL=http://localhost:4000 \
+ANTHROPIC_API_KEY=sk-local \
+ANTHROPIC_AUTH_TOKEN=sk-local \
+CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 \
+DISABLE_AUTOUPDATER=1 \
+claude "Use Bash to run: echo 'oi do qwen' > hello.txt && cat hello.txt" \
+  --print --effort low --dangerously-skip-permissions </dev/null
+```
+
+Saida do claude:
+
+```
+The file `hello.txt` has been created with the content "oi do qwen".
+```
+
+`hello.txt` criado no disco com o conteudo correto. Trail observado
+no servidor:
+
+```
+POST 1: [user] ['text','text','text']                                -> tool_use Bash
+POST 2: [user] ['text','text','text'] | [assistant] ['tool_use'] | [user] ['tool_result']
+        -> "The file hello.txt has been created..."
+```
+
+Multi-tool em sequencia (`Write` + `Read` no mesmo response) tambem
+funcionou: o Claude Code executou os dois e enviou os dois
+`tool_result` de volta na proxima request.
 
 ---
 

--- a/docs/MAC-BASE-SETUP.md
+++ b/docs/MAC-BASE-SETUP.md
@@ -6,11 +6,12 @@ de memoria unificada** - hardware abaixo do alvo original do projeto
 (M Max / Ultra com 64-128 GB).
 
 A documentacao oficial do repositorio assume Mac Max/Ultra. Em hardware
-mais modesto, tres problemas reproduziveis aparecem em sequencia:
+mais modesto, quatro problemas reproduziveis aparecem em sequencia:
 
 1. Tela de selecao de login do Claude Code mesmo com `ANTHROPIC_API_KEY` setado
 2. Vazamento de tokens internos do modelo (`<|im_end|>`, `<|endoftext|>`, ...) na resposta
 3. Respostas vazias ("(No output)") em todas as mensagens
+4. Tool-calls do Qwen 2.5 nao reconhecidos pelo parser do servidor
 
 Este guia explica a causa de cada um e a correcao aplicada nesta branch.
 
@@ -150,6 +151,48 @@ Aplicado por padrao nos dois launchers desta branch.
 
 ---
 
+## 4. Tool-calls do Qwen 2.5 nao reconhecidos
+
+### Sintoma
+
+Modo agentico nao executa nada. O modelo gera o pedido de tool, mas o
+Claude Code nao executa - aparece como texto puro:
+
+```
+> use Bash to print pwd
+<tools>
+{"name": "Bash", "arguments": {"command": "pwd"}}
+</tools>
+```
+
+### Causa
+
+O `parse_tool_calls` em `proxy/server.py` cobria `<tool_call>...</tool_call>`
+(formato Qwen 3.5 e variantes ChatML modernas) e `<|tool_call>...<tool_call|>`
+(Gemma 4 nativo), mas **nao** cobria `<tools>...</tools>` - o formato que o
+Qwen 2.5 Coder 14B emite naturalmente.
+
+Sem o parser reconhecer a tag, o servidor devolvia o conteudo como bloco
+de texto e o Claude Code nao tinha como executar.
+
+### Correcao
+
+Adicionado **Format 3.5** ao `parse_tool_calls` para reconhecer o
+wrapper `<tools>...</tools>`, com suporte a payload unico (objeto JSON)
+ou multiplos (array de objetos):
+
+```python
+pattern_qwen25 = r'<tools>\s*(.*?)\s*</tools>'
+for match in re.finditer(pattern_qwen25, text, re.DOTALL):
+    content = match.group(1).strip()
+    call_data = json.loads(content)
+    # aceita lista [{"name":..,"arguments":..}, ...] ou um objeto unico
+```
+
+Validado com `Bash({"command":"pwd"})` retornando `stop_reason: tool_use`.
+
+---
+
 ## Modelo recomendado para 16 GB
 
 A tabela oficial do repo nao cobre 16 GB - so 8-16 GB ("modelos pequenos
@@ -159,19 +202,26 @@ A tabela oficial do repo nao cobre 16 GB - so 8-16 GB ("modelos pequenos
 |---|---|---|---|---|---|
 | Qwen 3.5 4B 4-bit | 2.5 GB | 3-5 GB | 25-40 tok/s | Falha frequente | Apenas modo Chat |
 | Llama 3.1 8B 4-bit | 5 GB | 5-7 GB | 15-25 tok/s | Mediano | Compromisso |
-| Qwen 2.5 Coder 14B 4-bit | 8 GB | 9-11 GB | 10-15 tok/s | OK | Bom para codigo |
-| Gemma 4 31B Abliterated 4-bit | 18 GB | 18 GB | 5-8 tok/s | OK (testado pelo upstream) | Tool-calls confiaveis, vai swappar |
+| **Qwen 2.5 Coder 14B 4-bit** | **7.8 GB** | **9-11 GB** | **10-15 tok/s** | **OK (Format 3.5)** | **Padrao desta branch** |
+| Gemma 4 31B Abliterated 4-bit | 18 GB | 18+ GB | OOM em 16 GB | nao testavel | Inviavel em 16 GB |
 
-Os launchers desta branch usam **Gemma 4 31B** por padrao porque eh o
-modelo cujo formato de tool-call ja eh nativo no `proxy/server.py` do
-upstream e cuja confiabilidade em tool-calls foi validada pelo autor
-original do repo. Em 16 GB de RAM ele swappa cerca de 2 GB para o SSD,
-ficando lento mas funcional.
+Os launchers desta branch usam **Qwen 2.5 Coder 14B 4-bit MLX** por
+padrao. Razoes:
+
+- 7.8 GB de pesos cabem em 16 GB de memoria unificada **sem swap**
+- O parser `<tools>` (Format 3.5) ja foi adicionado em `proxy/server.py`
+- Tool-calls validados com `Bash`/`Read`/`Glob`
+- Boa qualidade em codigo e em PT-BR
+
+O Gemma 4 31B foi testado primeiro (eh o padrao do upstream) mas crasha
+com `kIOGPUCommandBufferCallbackErrorOutOfMemory` na primeira inferencia
+em 16 GB - os 18 GB de pesos simplesmente nao cabem com macOS + apps
+abertos consumindo RAM.
 
 Para usar outro modelo, exporte `MLX_MODEL` antes de chamar o launcher:
 
 ```bash
-MLX_MODEL=mlx-community/Qwen2.5-Coder-14B-Instruct-4bit ./launchers/Claude\ Chat.command
+MLX_MODEL=mlx-community/Llama-3.1-8B-Instruct-4bit ./launchers/Claude\ Chat.command
 ```
 
 ---

--- a/docs/MAC-BASE-SETUP.md
+++ b/docs/MAC-BASE-SETUP.md
@@ -1,0 +1,198 @@
+# Mac Base / Pro 16 GB Setup Guide
+
+Este documento descreve as adaptacoes necessarias para rodar
+`claude-code-local` em MacBooks Apple Silicon de entrada/Pro com **16 GB
+de memoria unificada** - hardware abaixo do alvo original do projeto
+(M Max / Ultra com 64-128 GB).
+
+A documentacao oficial do repositorio assume Mac Max/Ultra. Em hardware
+mais modesto, tres problemas reproduziveis aparecem em sequencia:
+
+1. Tela de selecao de login do Claude Code mesmo com `ANTHROPIC_API_KEY` setado
+2. Vazamento de tokens internos do modelo (`<|im_end|>`, `<|endoftext|>`, ...) na resposta
+3. Respostas vazias ("(No output)") em todas as mensagens
+
+Este guia explica a causa de cada um e a correcao aplicada nesta branch.
+
+---
+
+## 1. Bug do macOS keychain - tela de login persistente
+
+### Sintoma
+
+Apos rodar o launcher, voce ve a tela de selecao do Claude Code:
+
+```
+Select login method:
+  1. Claude account with subscription
+  2. Anthropic Console account
+  3. 3rd-party platform
+```
+
+Mesmo com `ANTHROPIC_API_KEY=sk-local` exportado no ambiente.
+
+### Causa
+
+Bug conhecido do Claude Code 2.1.x no macOS - issues
+[#25069](https://github.com/anthropics/claude-code/issues/25069) e
+[#27900](https://github.com/anthropics/claude-code/issues/27900) no
+repositorio oficial. A logica de verificacao do keychain do macOS roda
+**antes** da leitura da variavel de ambiente, e quando o keychain esta
+vazio o CLI cai no fluxo OAuth em vez de usar a env var.
+
+A flag `--bare` que o repositorio original passa nos launchers nao
+existe nas versoes recentes do CLI.
+
+### Correcao
+
+Combinacao de tres ajustes:
+
+1. Setar `hasCompletedOnboarding: true` em `~/.claude.json`:
+   ```bash
+   python3 -c "
+   import json, pathlib
+   p = pathlib.Path.home() / '.claude.json'
+   d = json.loads(p.read_text()) if p.exists() else {}
+   d['hasCompletedOnboarding'] = True
+   p.write_text(json.dumps(d, indent=2))
+   "
+   ```
+
+2. Exportar `ANTHROPIC_AUTH_TOKEN` junto com `ANTHROPIC_API_KEY` (a
+   presenca do auth token destrava o caminho de API key no modo
+   interativo).
+
+3. Setar `DISABLE_LOGIN_COMMAND=1` para esconder o comando `/login`
+   dentro da sessao interativa.
+
+Os launchers `Claude Chat.command` e `Claude Agentico.command` aplicam
+os tres automaticamente.
+
+---
+
+## 2. Vazamento de tokens internos do modelo
+
+### Sintoma
+
+Em vez da resposta esperada, voce ve:
+
+```
+> me fale sobre typescript
+<|endoftext|><|im_start|>user
+<system-
+```
+
+Os tokens especiais do tokenizer aparecem no texto da resposta.
+
+### Causa
+
+O `clean_response` em `proxy/server.py` so tinha logica para os stop
+markers do **Gemma 4** (`<turn|>`, `<|turn>`). Quando o servidor roda
+qualquer outro modelo - Qwen, Llama, modelos ChatML em geral - os
+markers `<|im_end|>`, `<|im_start|>`, `<|endoftext|>`, `<|eot_id|>` nao
+eram tratados. O modelo sinalizava fim de turno corretamente, mas o
+servidor nao truncava no marker e o texto vazava.
+
+### Correcao
+
+Patch em `proxy/server.py:132`:
+
+```python
+# Antes
+for stop_marker in ['<turn|>', '<|turn>']:
+
+# Depois
+for stop_marker in ['<turn|>', '<|turn>', '<|im_end|>', '<|endoftext|>',
+                    '<|im_start|>', '<|end_of_text|>', '<|eot_id|>']:
+```
+
+Truncamento de saida no primeiro marker encontrado, agora cobrindo
+ChatML (Qwen, Mistral, varios modelos), Llama 3.x e Gemma.
+
+---
+
+## 3. Extended thinking quebra modelos pequenos
+
+### Sintoma
+
+Toda mensagem retorna "(No output)" no Claude Code, mesmo sem tools
+e mesmo apos o fix de stop markers.
+
+No log do servidor MLX:
+
+```
+[06:14:25] POST /v1/messages tools=25
+[06:14:25]   Generated: 27 tokens - "O usuario esta testando o sistema..."
+[06:14:25] POST /v1/messages tools=25
+[06:14:25]   Generated: 6 tokens - "(No output)"
+```
+
+### Causa
+
+O Claude Code 2.1 introduziu **extended thinking**: para cada turno,
+faz duas chamadas ao modelo - a primeira pede `thinking` (cadeia de
+raciocinio interna), a segunda pede `text` (resposta final).
+
+Modelos pequenos / quantizados gastam o orcamento todo na primeira
+chamada (raciocinando) e quando recebem a segunda nao tem mais o que
+gerar - emitem so `<|im_end|>` direto e o texto sai vazio.
+
+### Correcao
+
+Forcar `--effort low` no Claude Code, que desativa o extended thinking
+e faz cada turno virar uma unica chamada:
+
+```bash
+claude --model claude-sonnet-4-6 --effort low ...
+```
+
+Aplicado por padrao nos dois launchers desta branch.
+
+---
+
+## Modelo recomendado para 16 GB
+
+A tabela oficial do repo nao cobre 16 GB - so 8-16 GB ("modelos pequenos
+4B") e 18-36 GB ("Gemma 31B apertado"). Na pratica:
+
+| Modelo | Disco | RAM em uso | Velocidade | Tool-calls | Recomendacao |
+|---|---|---|---|---|---|
+| Qwen 3.5 4B 4-bit | 2.5 GB | 3-5 GB | 25-40 tok/s | Falha frequente | Apenas modo Chat |
+| Llama 3.1 8B 4-bit | 5 GB | 5-7 GB | 15-25 tok/s | Mediano | Compromisso |
+| Qwen 2.5 Coder 14B 4-bit | 8 GB | 9-11 GB | 10-15 tok/s | OK | Bom para codigo |
+| Gemma 4 31B Abliterated 4-bit | 18 GB | 18 GB | 5-8 tok/s | OK (testado pelo upstream) | Tool-calls confiaveis, vai swappar |
+
+Os launchers desta branch usam **Gemma 4 31B** por padrao porque eh o
+modelo cujo formato de tool-call ja eh nativo no `proxy/server.py` do
+upstream e cuja confiabilidade em tool-calls foi validada pelo autor
+original do repo. Em 16 GB de RAM ele swappa cerca de 2 GB para o SSD,
+ficando lento mas funcional.
+
+Para usar outro modelo, exporte `MLX_MODEL` antes de chamar o launcher:
+
+```bash
+MLX_MODEL=mlx-community/Qwen2.5-Coder-14B-Instruct-4bit ./launchers/Claude\ Chat.command
+```
+
+---
+
+## Limites realistas em 16 GB
+
+O que funciona bem:
+
+- Conversa, perguntas de codigo, geracao de snippets isolados
+- Explicacao de conceitos, debugging de stack traces colados
+- Codigo sensivel (NDA / juridico / saude) que nao pode sair da maquina
+- Trabalho offline (aviao, redes restritas)
+
+O que nao funciona bem:
+
+- Refatoracoes multi-arquivo com Edit/Write em loop
+- Sessoes agenticas longas (o KV cache enche e o Mac swappa)
+- Tarefas que exigem raciocinio nivel Claude Sonnet/Opus
+- Conhecimento factual sobre Brasil / cultura PT-BR (modelos pequenos
+  alucinam pesado nesse dominio)
+
+Para essas situacoes, usar o Claude na nuvem (`claude` sem
+`ANTHROPIC_BASE_URL`) continua sendo a opcao certa. O setup local eh
+complementar, nao substituto, em hardware modesto.

--- a/docs/MAC-BASE-SETUP.md
+++ b/docs/MAC-BASE-SETUP.md
@@ -6,12 +6,13 @@ de memoria unificada** - hardware abaixo do alvo original do projeto
 (M Max / Ultra com 64-128 GB).
 
 A documentacao oficial do repositorio assume Mac Max/Ultra. Em hardware
-mais modesto, quatro problemas reproduziveis aparecem em sequencia:
+mais modesto, cinco problemas reproduziveis aparecem em sequencia:
 
 1. Tela de selecao de login do Claude Code mesmo com `ANTHROPIC_API_KEY` setado
 2. Vazamento de tokens internos do modelo (`<|im_end|>`, `<|endoftext|>`, ...) na resposta
 3. Respostas vazias ("(No output)") em todas as mensagens
 4. Tool-calls do Qwen 2.5 nao reconhecidos pelo parser do servidor
+5. Claude Code chama `api.anthropic.com` no startup mesmo com `ANTHROPIC_BASE_URL` setado (vazamento de "100% offline")
 
 Este guia explica a causa de cada um e a correcao aplicada nesta branch.
 
@@ -190,6 +191,108 @@ for match in re.finditer(pattern_qwen25, text, re.DOTALL):
 ```
 
 Validado com `Bash({"command":"pwd"})` retornando `stop_reason: tool_use`.
+
+---
+
+## 5. Vazamento "100% offline" - Claude Code chama api.anthropic.com no startup
+
+Esta foi a descoberta mais grave durante a investigacao desta branch e
+nao tem nenhuma mencao no README do upstream.
+
+### Sintoma
+
+Apos aplicar todos os fixes anteriores, ao rodar:
+
+```bash
+ANTHROPIC_BASE_URL=http://localhost:4000 \
+ANTHROPIC_API_KEY=sk-local \
+claude --print --tools "" "Hi"
+```
+
+O processo trava por minutos sem qualquer chamada chegar ao servidor
+MLX local. Inspecionando com `lsof -p $PID`:
+
+```
+claude  25331  TCP mac:63057->160.79.104.10:https (ESTABLISHED)
+```
+
+O IP `160.79.104.10` resolve para **Anthropic, PBC** (whois confirma) e
+e o IP de `api.anthropic.com`. Ou seja, **mesmo com `ANTHROPIC_BASE_URL`
+apontando para localhost:4000, o Claude Code abre conexao HTTPS para o
+servidor real da Anthropic na inicializacao.**
+
+Isso e um vazamento serio para qualquer pessoa que pensa estar rodando
+"100% offline" - codigo, prompts e telemetria estao saindo da maquina
+mesmo com o setup local funcionando.
+
+### Causa
+
+O Claude Code 2.1.x dispara, na inicializacao, uma serie de chamadas
+"nao essenciais" antes de processar o prompt do usuario:
+
+- Telemetria (`tengu_*` events)
+- Feature flags via Statsig
+- Auto-install do marketplace oficial de plugins
+- Verificacao de auto-updater
+- Background tasks scheduling
+
+Todas essas chamadas vao para `api.anthropic.com` e `events.statsig.com`
+diretamente, sem passar pelo `ANTHROPIC_BASE_URL`. Isso esta confirmado
+nas strings do binario:
+
+```
+CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC
+CLAUDE_CODE_DISABLE_OFFICIAL_MARKETPLACE_AUTOINSTALL
+DISABLE_AUTOUPDATER
+CLAUDE_CODE_DISABLE_BACKGROUND_TASKS
+```
+
+### Correcao
+
+Exportar as quatro variaveis de ambiente nos launchers:
+
+```bash
+CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
+DISABLE_AUTOUPDATER=1
+CLAUDE_CODE_DISABLE_OFFICIAL_MARKETPLACE_AUTOINSTALL=1
+CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1
+```
+
+Com `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` confirmamos via
+`lsof -p $CLAUDE_PID` que **nenhuma** conexao TCP sai para o IP
+160.79.104.10 - o claude conecta exclusivamente em `localhost:4000`
+(o servidor MLX desta branch).
+
+### Validacao
+
+Apos os fixes, rodando:
+
+```bash
+CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 \
+ANTHROPIC_BASE_URL=http://localhost:4000 \
+ANTHROPIC_API_KEY=sk-local \
+ANTHROPIC_AUTH_TOKEN=sk-local \
+claude --print --tools "" --effort low "Hi" </dev/null
+```
+
+Saida obtida:
+
+```
+Hello! How can I assist you today?
+```
+
+Servidor MLX (`/tmp/mlx-server.log`):
+
+```
+[21:31:07]   Generated: 10 tokens in 63.4s (0.2 tok/s)
+[21:31:07]   ← OK (10 tok) Hello! How can I assist you today?...
+```
+
+**Nenhuma** chamada saiu da maquina. Verificado com lsof.
+
+> Observacao adicional: em modo `--print`, e necessario fechar
+> o stdin com `</dev/null`, caso contrario o claude trava esperando
+> input mesmo com o prompt passado como argumento.
 
 ---
 

--- a/launchers/Claude Agentico.command
+++ b/launchers/Claude Agentico.command
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Claude Agentico - Claude Code on Gemma 4 31B in AGENTIC mode (with tools)
+# Double-click to launch
+#
+# Same as "Gemma 4 Code.command" but tuned for Mac base/Pro (16-32 GB):
+#   - forces --effort low to disable Claude Code 2.1 extended thinking
+#     (small models can't handle the two-call thinking → answer flow)
+#   - applies the macOS keychain auth workaround so ANTHROPIC_API_KEY is
+#     actually honored in interactive mode
+#
+# Tool-call reliability on a 16 GB Mac is lower than on Max/Ultra hardware:
+# expect the model to swap, run at 5-8 tok/s, and occasionally produce
+# garbled tool calls. The server already retries via recover_garbled_tool_json,
+# but multi-step tool sequences can still fail. For mission-critical agentic
+# work, fall back to the cloud Claude (claude without ANTHROPIC_BASE_URL).
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/claude-local-common.sh"
+
+CLAUDE_BIN="${CLAUDE_BIN:-$(command -v claude || echo $HOME/.local/bin/claude)}"
+
+MLX_MODEL_DEFAULT="$(resolve_mlx_model \
+  "$HOME/.cache/huggingface/hub/gemma-4-31b-it-abliterated-4bit-mlx" \
+  "divinetribe/gemma-4-31b-it-abliterated-4bit-mlx")"
+
+ensure_mlx_server "${MLX_MODEL:-$MLX_MODEL_DEFAULT}" \
+  "  Loading Gemma 4 31B Abliterated on MLX (~5-8 tok/s in 16 GB, may swap)..."
+
+clear
+echo ""
+echo "  Claude Code LOCAL - Modo AGENTICO (com ferramentas)"
+echo "  Modelo: Gemma 4 31B Abliterated"
+echo "  100% on-device - sem cloud, sem custo de API"
+echo ""
+echo "  Em 16 GB de RAM o modelo vai swappar. Tool-calls podem falhar."
+echo "  Para conversa simples, use o launcher Chat."
+echo ""
+
+ANTHROPIC_BASE_URL=http://localhost:4000 \
+ANTHROPIC_API_KEY=sk-local \
+ANTHROPIC_AUTH_TOKEN=sk-local \
+DISABLE_LOGIN_COMMAND=1 \
+CLAUDE_SESSION_LABEL="Local Agentic" \
+exec "$CLAUDE_BIN" --model claude-sonnet-4-6 \
+  --effort low \
+  --permission-mode auto \
+  --settings "$SCRIPT_DIR/lib/local-settings.json"

--- a/launchers/Claude Agentico.command
+++ b/launchers/Claude Agentico.command
@@ -1,18 +1,22 @@
 #!/bin/bash
-# Claude Agentico - Claude Code on Gemma 4 31B in AGENTIC mode (with tools)
+# Claude Agentico - Claude Code on Qwen 2.5 Coder 14B in AGENTIC mode (with tools)
 # Double-click to launch
 #
-# Same as "Gemma 4 Code.command" but tuned for Mac base/Pro (16-32 GB):
+# Designed for Mac base/Pro with 16-32 GB unified memory:
 #   - forces --effort low to disable Claude Code 2.1 extended thinking
 #     (small models can't handle the two-call thinking → answer flow)
 #   - applies the macOS keychain auth workaround so ANTHROPIC_API_KEY is
 #     actually honored in interactive mode
 #
-# Tool-call reliability on a 16 GB Mac is lower than on Max/Ultra hardware:
-# expect the model to swap, run at 5-8 tok/s, and occasionally produce
-# garbled tool calls. The server already retries via recover_garbled_tool_json,
-# but multi-step tool sequences can still fail. For mission-critical agentic
-# work, fall back to the cloud Claude (claude without ANTHROPIC_BASE_URL).
+# Why Qwen 2.5 Coder 14B 4-bit MLX:
+#   - 7.8 GB weights → fits in 16 GB unified memory without swapping
+#   - Reliable tool-call emission (validated against Bash/Read/Glob)
+#   - Native MLX 4-bit quant for Apple Silicon (no GGUF translation)
+#
+# Tool-call reliability on a 16 GB Mac is lower than on Max/Ultra hardware.
+# Expect ~10-15 tok/s and occasional garbled tool calls; the server already
+# retries via recover_garbled_tool_json. For mission-critical agentic work,
+# fall back to the cloud Claude (claude without ANTHROPIC_BASE_URL).
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/claude-local-common.sh"
@@ -20,19 +24,20 @@ source "$SCRIPT_DIR/lib/claude-local-common.sh"
 CLAUDE_BIN="${CLAUDE_BIN:-$(command -v claude || echo $HOME/.local/bin/claude)}"
 
 MLX_MODEL_DEFAULT="$(resolve_mlx_model \
-  "$HOME/.cache/huggingface/hub/gemma-4-31b-it-abliterated-4bit-mlx" \
-  "divinetribe/gemma-4-31b-it-abliterated-4bit-mlx")"
+  "$HOME/.cache/huggingface/hub/Qwen2.5-Coder-14B-Instruct-4bit" \
+  "mlx-community/Qwen2.5-Coder-14B-Instruct-4bit")"
 
 ensure_mlx_server "${MLX_MODEL:-$MLX_MODEL_DEFAULT}" \
-  "  Loading Gemma 4 31B Abliterated on MLX (~5-8 tok/s in 16 GB, may swap)..."
+  "  Loading Qwen 2.5 Coder 14B 4-bit on MLX (~10-15 tok/s in 16 GB)..."
 
 clear
 echo ""
 echo "  Claude Code LOCAL - Modo AGENTICO (com ferramentas)"
-echo "  Modelo: Gemma 4 31B Abliterated"
+echo "  Modelo: Qwen 2.5 Coder 14B (4-bit MLX, ~7.8 GB)"
 echo "  100% on-device - sem cloud, sem custo de API"
 echo ""
-echo "  Em 16 GB de RAM o modelo vai swappar. Tool-calls podem falhar."
+echo "  Em 16 GB de RAM espere ~10-15 tok/s e ocasionais"
+echo "  falhas em sequencias longas de tool-calls."
 echo "  Para conversa simples, use o launcher Chat."
 echo ""
 

--- a/launchers/Claude Agentico.command
+++ b/launchers/Claude Agentico.command
@@ -16,6 +16,13 @@
 #   - Reliable tool-call emission (validated against Bash/Read/Glob)
 #   - Native MLX 4-bit quant for Apple Silicon (no GGUF translation)
 #
+# Why MLX_KV_BITS=4 / MLX_KV_QUANT_START=0:
+#   - Claude Code 2.1 sends a ~5860-token system prompt on every request,
+#     which makes the KV cache the main RAM consumer (not the weights).
+#   - Quantizing the cache to 4-bit from token 0 keeps prefill below the
+#     16 GB ceiling and avoids kIOGPUCommandBufferCallbackErrorOutOfMemory
+#     crashes mid-conversation.
+#
 # Tool-call reliability on a 16 GB Mac is lower than on Max/Ultra hardware.
 # Expect ~10-15 tok/s and occasional garbled tool calls; the server already
 # retries via recover_garbled_tool_json. For mission-critical agentic work,
@@ -30,8 +37,13 @@ MLX_MODEL_DEFAULT="$(resolve_mlx_model \
   "$HOME/.cache/huggingface/hub/Qwen2.5-Coder-14B-Instruct-4bit" \
   "mlx-community/Qwen2.5-Coder-14B-Instruct-4bit")"
 
+# 4-bit KV cache from token 0: required to stay under 16 GB with Claude
+# Code 2.1's ~5860-token system prompt. Override with stronger machines.
+export MLX_KV_BITS="${MLX_KV_BITS:-4}"
+export MLX_KV_QUANT_START="${MLX_KV_QUANT_START:-0}"
+
 ensure_mlx_server "${MLX_MODEL:-$MLX_MODEL_DEFAULT}" \
-  "  Loading Qwen 2.5 Coder 14B 4-bit on MLX (~10-15 tok/s in 16 GB)..."
+  "  Loading Qwen 2.5 Coder 14B 4-bit on MLX (KV=4-bit, ~10-15 tok/s in 16 GB)..."
 
 clear
 echo ""

--- a/launchers/Claude Agentico.command
+++ b/launchers/Claude Agentico.command
@@ -7,6 +7,9 @@
 #     (small models can't handle the two-call thinking → answer flow)
 #   - applies the macOS keychain auth workaround so ANTHROPIC_API_KEY is
 #     actually honored in interactive mode
+#   - disables non-essential traffic so the CLI does not reach out to
+#     api.anthropic.com on startup (telemetry, statsig, marketplace,
+#     autoupdater). Without this, "100% offline" is not actually offline.
 #
 # Why Qwen 2.5 Coder 14B 4-bit MLX:
 #   - 7.8 GB weights → fits in 16 GB unified memory without swapping
@@ -45,6 +48,10 @@ ANTHROPIC_BASE_URL=http://localhost:4000 \
 ANTHROPIC_API_KEY=sk-local \
 ANTHROPIC_AUTH_TOKEN=sk-local \
 DISABLE_LOGIN_COMMAND=1 \
+CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 \
+DISABLE_AUTOUPDATER=1 \
+CLAUDE_CODE_DISABLE_OFFICIAL_MARKETPLACE_AUTOINSTALL=1 \
+CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1 \
 CLAUDE_SESSION_LABEL="Local Agentic" \
 exec "$CLAUDE_BIN" --model claude-sonnet-4-6 \
   --effort low \

--- a/launchers/Claude Chat.command
+++ b/launchers/Claude Chat.command
@@ -1,10 +1,16 @@
 #!/bin/bash
-# Claude Chat - Claude Code on Gemma 4 31B in CHAT-ONLY mode (no tools)
+# Claude Chat - Claude Code on Qwen 2.5 Coder 14B in CHAT-ONLY mode (no tools)
 # Double-click to launch
 #
 # Designed for Mac base/Pro with 16-32 GB unified memory, where agentic
-# tool-use sessions are unreliable due to RAM pressure and the Claude Code
+# tool-use sessions can be unreliable due to RAM pressure and the Claude Code
 # 2.1 extended-thinking flow that splits each turn into two model calls.
+#
+# Why Qwen 2.5 Coder 14B 4-bit MLX:
+#   - 7.8 GB of weights → fits in 16 GB without swapping
+#   - 14B is large enough to follow Claude Code's system prompt structure
+#   - Strong code/reasoning quality, good PT-BR support
+#   - Native MLX 4-bit quant for Apple Silicon (no GGUF translation layer)
 #
 # This launcher:
 #   - disables all tools (--tools "")
@@ -24,16 +30,16 @@ source "$SCRIPT_DIR/lib/claude-local-common.sh"
 CLAUDE_BIN="${CLAUDE_BIN:-$(command -v claude || echo $HOME/.local/bin/claude)}"
 
 MLX_MODEL_DEFAULT="$(resolve_mlx_model \
-  "$HOME/.cache/huggingface/hub/gemma-4-31b-it-abliterated-4bit-mlx" \
-  "divinetribe/gemma-4-31b-it-abliterated-4bit-mlx")"
+  "$HOME/.cache/huggingface/hub/Qwen2.5-Coder-14B-Instruct-4bit" \
+  "mlx-community/Qwen2.5-Coder-14B-Instruct-4bit")"
 
 ensure_mlx_server "${MLX_MODEL:-$MLX_MODEL_DEFAULT}" \
-  "  Loading Gemma 4 31B Abliterated on MLX (~5-8 tok/s in 16 GB, may swap)..."
+  "  Loading Qwen 2.5 Coder 14B 4-bit on MLX (~10-15 tok/s in 16 GB)..."
 
 clear
 echo ""
 echo "  Claude Code LOCAL - Modo CHAT (sem ferramentas)"
-echo "  Modelo: Gemma 4 31B Abliterated"
+echo "  Modelo: Qwen 2.5 Coder 14B (4-bit MLX, ~7.8 GB)"
 echo "  100% on-device - sem cloud, sem custo de API"
 echo ""
 echo "  Use para: perguntas de codigo, conceitos, debug, conversa."

--- a/launchers/Claude Chat.command
+++ b/launchers/Claude Chat.command
@@ -39,8 +39,13 @@ MLX_MODEL_DEFAULT="$(resolve_mlx_model \
   "$HOME/.cache/huggingface/hub/Qwen2.5-Coder-14B-Instruct-4bit" \
   "mlx-community/Qwen2.5-Coder-14B-Instruct-4bit")"
 
+# 4-bit KV cache from token 0 keeps the chat session under 16 GB even after
+# many turns of accumulated context.
+export MLX_KV_BITS="${MLX_KV_BITS:-4}"
+export MLX_KV_QUANT_START="${MLX_KV_QUANT_START:-0}"
+
 ensure_mlx_server "${MLX_MODEL:-$MLX_MODEL_DEFAULT}" \
-  "  Loading Qwen 2.5 Coder 14B 4-bit on MLX (~10-15 tok/s in 16 GB)..."
+  "  Loading Qwen 2.5 Coder 14B 4-bit on MLX (KV=4-bit, ~10-15 tok/s in 16 GB)..."
 
 clear
 echo ""

--- a/launchers/Claude Chat.command
+++ b/launchers/Claude Chat.command
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Claude Chat - Claude Code on Gemma 4 31B in CHAT-ONLY mode (no tools)
+# Double-click to launch
+#
+# Designed for Mac base/Pro with 16-32 GB unified memory, where agentic
+# tool-use sessions are unreliable due to RAM pressure and the Claude Code
+# 2.1 extended-thinking flow that splits each turn into two model calls.
+#
+# This launcher:
+#   - disables all tools (--tools "")
+#   - forces --effort low so Claude Code does NOT request extended thinking
+#     (small/quantized models exhaust their budget thinking and emit empty
+#      replies on the second call → "(No output)")
+#   - applies the macOS keychain auth workaround (ANTHROPIC_AUTH_TOKEN +
+#     hasCompletedOnboarding=true) so the local API key is actually used
+#     instead of the model-selection login prompt
+#
+# Use this for: code Q&A, snippet generation, debugging help, conversations.
+# For tool-driven sessions, see "Claude Agentico.command".
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/claude-local-common.sh"
+
+CLAUDE_BIN="${CLAUDE_BIN:-$(command -v claude || echo $HOME/.local/bin/claude)}"
+
+MLX_MODEL_DEFAULT="$(resolve_mlx_model \
+  "$HOME/.cache/huggingface/hub/gemma-4-31b-it-abliterated-4bit-mlx" \
+  "divinetribe/gemma-4-31b-it-abliterated-4bit-mlx")"
+
+ensure_mlx_server "${MLX_MODEL:-$MLX_MODEL_DEFAULT}" \
+  "  Loading Gemma 4 31B Abliterated on MLX (~5-8 tok/s in 16 GB, may swap)..."
+
+clear
+echo ""
+echo "  Claude Code LOCAL - Modo CHAT (sem ferramentas)"
+echo "  Modelo: Gemma 4 31B Abliterated"
+echo "  100% on-device - sem cloud, sem custo de API"
+echo ""
+echo "  Use para: perguntas de codigo, conceitos, debug, conversa."
+echo "  Para criar/editar arquivos use o launcher Agentico."
+echo ""
+
+ANTHROPIC_BASE_URL=http://localhost:4000 \
+ANTHROPIC_API_KEY=sk-local \
+ANTHROPIC_AUTH_TOKEN=sk-local \
+DISABLE_LOGIN_COMMAND=1 \
+CLAUDE_SESSION_LABEL="Local Chat" \
+exec "$CLAUDE_BIN" --model claude-sonnet-4-6 \
+  --tools "" \
+  --effort low \
+  --settings "$SCRIPT_DIR/lib/local-settings.json"

--- a/launchers/Claude Chat.command
+++ b/launchers/Claude Chat.command
@@ -20,6 +20,12 @@
 #   - applies the macOS keychain auth workaround (ANTHROPIC_AUTH_TOKEN +
 #     hasCompletedOnboarding=true) so the local API key is actually used
 #     instead of the model-selection login prompt
+#   - disables all non-essential traffic to api.anthropic.com (telemetry,
+#     statsig, marketplace auto-install, autoupdater, background tasks).
+#     Without CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 the CLI still
+#     reaches out to api.anthropic.com on startup even with
+#     ANTHROPIC_BASE_URL pointing at localhost — which means "running
+#     offline" is not actually offline by default.
 #
 # Use this for: code Q&A, snippet generation, debugging help, conversations.
 # For tool-driven sessions, see "Claude Agentico.command".
@@ -50,6 +56,10 @@ ANTHROPIC_BASE_URL=http://localhost:4000 \
 ANTHROPIC_API_KEY=sk-local \
 ANTHROPIC_AUTH_TOKEN=sk-local \
 DISABLE_LOGIN_COMMAND=1 \
+CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 \
+DISABLE_AUTOUPDATER=1 \
+CLAUDE_CODE_DISABLE_OFFICIAL_MARKETPLACE_AUTOINSTALL=1 \
+CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1 \
 CLAUDE_SESSION_LABEL="Local Chat" \
 exec "$CLAUDE_BIN" --model claude-sonnet-4-6 \
   --tools "" \

--- a/launchers/lib/claude-local-common.sh
+++ b/launchers/lib/claude-local-common.sh
@@ -114,7 +114,10 @@ ensure_mlx_server() {
   fi
 
   echo "$msg"
-  MLX_MODEL="$desired" "$MLX_PYTHON" "$MLX_SERVER" >/tmp/mlx-server.log 2>&1 &
+  MLX_MODEL="$desired" \
+  MLX_KV_BITS="${MLX_KV_BITS:-}" \
+  MLX_KV_QUANT_START="${MLX_KV_QUANT_START:-}" \
+  "$MLX_PYTHON" "$MLX_SERVER" >/tmp/mlx-server.log 2>&1 &
   if ! _wait_for_mlx_health; then
     echo "  ERROR: MLX server failed to respond on port 4000 within 120s"
     echo "  Check /tmp/mlx-server.log for details"
@@ -135,7 +138,10 @@ force_restart_mlx_server() {
   fi
 
   echo "$msg"
-  MLX_MODEL="$desired" "$MLX_PYTHON" "$MLX_SERVER" >/tmp/mlx-server.log 2>&1 &
+  MLX_MODEL="$desired" \
+  MLX_KV_BITS="${MLX_KV_BITS:-}" \
+  MLX_KV_QUANT_START="${MLX_KV_QUANT_START:-}" \
+  "$MLX_PYTHON" "$MLX_SERVER" >/tmp/mlx-server.log 2>&1 &
   if ! _wait_for_mlx_health; then
     echo "  ERROR: MLX server failed to respond on port 4000 within 120s"
     echo "  Check /tmp/mlx-server.log for details"

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -426,6 +426,55 @@ def parse_tool_calls(text):
                 else:
                     log(f"  Warning: unrecoverable <tools> JSON: {content[:100]}")
 
+    # Format 3.6: JSON inside markdown code block — ```json\n{"name":..,"arguments":..}\n```
+    # Some Qwen 2.5 fine-tunes emit tool calls as a fenced code block when the
+    # system prompt / chat template doesn't explicitly tell them to use the
+    # native <tool_call> wrapper. Two sub-cases supported:
+    #   (a) single JSON object inside the fence
+    #   (b) multiple JSON objects back-to-back inside the same fence (no
+    #       array, no commas) — the model expressing several sequential
+    #       tool calls in one go. Use raw_decode in a loop to extract them.
+    if not tool_calls:
+        pattern_md = r'```(?:json|tool[_ ]?call)?\s*\n?(.*?)\s*\n?```'
+        decoder_md = json.JSONDecoder()
+        for match in re.finditer(pattern_md, text, re.DOTALL):
+            content = match.group(1).strip()
+            if not content.lstrip().startswith("{"):
+                continue
+            extracted_in_block = []
+            pos = 0
+            while pos < len(content):
+                # Skip whitespace and stray commas between objects
+                while pos < len(content) and content[pos] in " \t\n\r,":
+                    pos += 1
+                if pos >= len(content):
+                    break
+                if content[pos] != "{":
+                    break
+                try:
+                    obj, end_pos = decoder_md.raw_decode(content, pos)
+                except json.JSONDecodeError:
+                    break
+                pos = end_pos
+                if not isinstance(obj, dict):
+                    continue
+                name = obj.get("name") or obj.get("tool")
+                args = (
+                    obj.get("arguments")
+                    or obj.get("parameters")
+                    or obj.get("args")
+                    or obj.get("input")
+                )
+                if name and isinstance(args, dict):
+                    extracted_in_block.append({"name": name, "arguments": args})
+            if extracted_in_block:
+                tool_calls.extend(extracted_in_block)
+                remaining = remaining.replace(match.group(0), "", 1)
+                log(
+                    f"  Markdown-fenced tool calls: "
+                    f"{', '.join(t['name'] for t in extracted_in_block)}"
+                )
+
     # Format 4: Garbled — no tags at all, but parameter= patterns in raw text
     if not tool_calls:
         # Look for any tool name followed by parameter patterns
@@ -901,9 +950,11 @@ def generate_response(body):
     # ─── Retry logic: if model expressed intent to use a tool but we got no valid calls ───
     tool_intent_phrases = [
         "here's the command", "bash(", "read(", "edit(", "write(",
-        "<tool_call>", "<function=",
+        "<tool_call>", "<function=", "<tools>", '"name":', '"arguments":',
+        '"parameters":', "```json", "```tool",
     ]
     if not tool_calls and any(p in remaining_text.lower() for p in tool_intent_phrases):
+        log(f"  Tool intent detected but parser missed it. Raw text (400 chars): {remaining_text[:400]!r}")
         for retry in range(MAX_TOOL_RETRIES):
             log(f"  Retry {retry+1}/{MAX_TOOL_RETRIES}: tool intent detected but no valid tool call, re-prompting")
             retry_messages = messages + [
@@ -947,17 +998,48 @@ def generate_response(body):
         content_blocks.append({"type": "text", "text": remaining_text.strip()})
 
     if tool_calls:
-        # If we have tool calls but no text, add empty text block (Anthropic requires at least one)
-        if not content_blocks:
-            content_blocks.append({"type": "text", "text": ""})
+        # NOTE: previously this branch prepended an empty text block
+        # ({"type":"text","text":""}) "because Anthropic requires at least one
+        # block". That's incorrect — the Anthropic API accepts a content list
+        # made up of only tool_use blocks. The empty text block actively breaks
+        # Claude Code 2.1: it reads the first (empty) text block, decides the
+        # response is "(No output)", and silently discards the tool_use blocks
+        # that follow. Drop the empty text block entirely.
+
+        # Build a {tool_name: allowed_input_keys} map from the request schema
+        # so we can drop any extra keys the model hallucinated. Claude Code
+        # 2.1 silently rejects a tool_use response whose input has fields not
+        # declared in the tool's input_schema (e.g. Qwen 2.5 likes to add a
+        # "description" field next to "command" for Bash).
+        # Note: anthropic_tools here is the (possibly filtered) tool list
+        # the request actually sent — we must rebuild from `body["tools"]`
+        # to honor any code-mode trimming applied earlier in this function.
+        current_tools = body.get("tools", []) or anthropic_tools or []
+        tool_schemas = {}
+        for atool in current_tools:
+            schema = atool.get("input_schema") or {}
+            props = schema.get("properties") or {}
+            tool_schemas[atool.get("name", "")] = set(props.keys())
+        if os.environ.get("MLX_DEBUG_RESPONSE"):
+            log(f"  TOOL SCHEMAS: {tool_schemas}")
 
         for tc in tool_calls:
             tool_id = f"toolu_{uuid.uuid4().hex[:24]}"
+            raw_input = tc["arguments"] if isinstance(tc.get("arguments"), dict) else {}
+            allowed = tool_schemas.get(tc["name"])
+            if allowed is not None:
+                filtered = {k: v for k, v in raw_input.items() if k in allowed}
+                dropped = [k for k in raw_input if k not in allowed]
+                if dropped:
+                    log(f"  Filtered extra input keys for {tc['name']}: {dropped}")
+                tool_input = filtered
+            else:
+                tool_input = raw_input
             content_blocks.append({
                 "type": "tool_use",
                 "id": tool_id,
                 "name": tc["name"],
-                "input": tc["arguments"],
+                "input": tool_input,
             })
         finish_reason = "tool_use"
         log(f"  Tool calls: {', '.join(tc['name'] for tc in tool_calls)}")
@@ -991,6 +1073,105 @@ def send_json(handler, status, data):
     handler.wfile.write(resp)
 
 
+def send_anthropic_stream(handler, result):
+    """Replay a fully-generated Anthropic Messages response as a stream of
+    Server-Sent Events. Claude Code 2.1 sends `stream: true` for any request
+    that involves tools and silently discards a non-streaming response, so
+    we must emit the SSE event sequence even though we already have the
+    complete answer.
+
+    Event order (Anthropic Messages streaming spec):
+      message_start
+      for each content block i:
+        content_block_start
+        content_block_delta (text_delta for text, input_json_delta for tool_use)
+        content_block_stop
+      message_delta (with stop_reason)
+      message_stop
+    """
+    handler.send_response(200)
+    handler.send_header("Content-Type", "text/event-stream")
+    handler.send_header("Cache-Control", "no-cache")
+    # We replay a fully-generated message in one shot, so signal close so
+    # the client (Claude Code 2.1) doesn't keep waiting for more events.
+    handler.send_header("Connection", "close")
+    handler.end_headers()
+
+    def emit(event_type, payload):
+        handler.wfile.write(f"event: {event_type}\n".encode())
+        handler.wfile.write(f"data: {json.dumps(payload)}\n\n".encode())
+        handler.wfile.flush()
+
+    msg_start = {
+        "type": "message_start",
+        "message": {
+            "id": result["id"],
+            "type": "message",
+            "role": "assistant",
+            "model": result["model"],
+            "content": [],
+            "stop_reason": None,
+            "stop_sequence": None,
+            "usage": {
+                "input_tokens": result["usage"]["input_tokens"],
+                "output_tokens": 0,
+            },
+        },
+    }
+    emit("message_start", msg_start)
+
+    for idx, block in enumerate(result["content"]):
+        btype = block.get("type")
+        if btype == "text":
+            emit("content_block_start", {
+                "type": "content_block_start",
+                "index": idx,
+                "content_block": {"type": "text", "text": ""},
+            })
+            text = block.get("text", "")
+            if text:
+                emit("content_block_delta", {
+                    "type": "content_block_delta",
+                    "index": idx,
+                    "delta": {"type": "text_delta", "text": text},
+                })
+            emit("content_block_stop", {
+                "type": "content_block_stop",
+                "index": idx,
+            })
+        elif btype == "tool_use":
+            emit("content_block_start", {
+                "type": "content_block_start",
+                "index": idx,
+                "content_block": {
+                    "type": "tool_use",
+                    "id": block["id"],
+                    "name": block["name"],
+                    "input": {},
+                },
+            })
+            input_json = json.dumps(block.get("input", {}))
+            emit("content_block_delta", {
+                "type": "content_block_delta",
+                "index": idx,
+                "delta": {"type": "input_json_delta", "partial_json": input_json},
+            })
+            emit("content_block_stop", {
+                "type": "content_block_stop",
+                "index": idx,
+            })
+
+    emit("message_delta", {
+        "type": "message_delta",
+        "delta": {
+            "stop_reason": result.get("stop_reason"),
+            "stop_sequence": result.get("stop_sequence"),
+        },
+        "usage": {"output_tokens": result["usage"]["output_tokens"]},
+    })
+    emit("message_stop", {"type": "message_stop"})
+
+
 def get_path(full_path):
     return urlparse(full_path).path
 
@@ -1012,6 +1193,21 @@ class AnthropicHandler(BaseHTTPRequestHandler):
         body = json.loads(raw)
         tools_count = len(body.get("tools", []))
         log(f"POST {self.path} model={body.get('model','-')} max_tokens={body.get('max_tokens','-')} tools={tools_count}")
+        if os.environ.get("MLX_DEBUG_REQUEST"):
+            try:
+                msgs = body.get("messages", [])
+                roles_summary = []
+                for i, m in enumerate(msgs[-6:]):  # last 6 messages
+                    role = m.get("role", "?")
+                    content = m.get("content")
+                    if isinstance(content, str):
+                        roles_summary.append(f"[{role}] str({len(content)})")
+                    elif isinstance(content, list):
+                        types = [b.get("type", "?") for b in content if isinstance(b, dict)]
+                        roles_summary.append(f"[{role}] {types}")
+                log(f"  DEBUG msg trail (last 6/{len(msgs)}): {' | '.join(roles_summary)}")
+            except Exception as e:
+                log(f"  DEBUG dump failed: {e}")
 
         if path in ("/v1/messages", "/messages"):
             try:
@@ -1023,7 +1219,20 @@ class AnthropicHandler(BaseHTTPRequestHandler):
                     log(f"  ← OK ({result['usage']['output_tokens']} tok) {preview}...")
                 elif first["type"] == "tool_use":
                     log(f"  ← OK ({result['usage']['output_tokens']} tok) [tool_use: {first['name']}]")
-                send_json(self, 200, result)
+                if os.environ.get("MLX_DEBUG_RESPONSE"):
+                    try:
+                        log(f"  RESPONSE JSON: {json.dumps(result, ensure_ascii=False)[:1500]}")
+                    except Exception as e:
+                        log(f"  RESPONSE dump failed: {e}")
+
+                # Anthropic SSE streaming: when the client requests stream=true
+                # we MUST respond with text/event-stream, otherwise Claude Code
+                # 2.1 silently discards the response (it expects SSE for any
+                # request with tools and falls through on plain JSON).
+                if body.get("stream"):
+                    send_anthropic_stream(self, result)
+                else:
+                    send_json(self, 200, result)
             except Exception as e:
                 log(f"  ← ERROR: {e}")
                 import traceback

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -128,8 +128,8 @@ def clean_response(text):
     text = strip_think_tags(text)
     # Llama 3.x: strip function-call prefix token
     text = text.replace('<|python_tag|>', '').strip()
-    # Gemma 4: truncate at end-of-turn or start of a new turn
-    for stop_marker in ['<turn|>', '<|turn>']:
+    # Gemma 4 + Qwen + ChatML: truncate at end-of-turn or start of a new turn
+    for stop_marker in ['<turn|>', '<|turn>', '<|im_end|>', '<|endoftext|>', '<|im_start|>', '<|end_of_text|>', '<|eot_id|>']:
         if stop_marker in text:
             text = text[:text.index(stop_marker)].strip()
             break

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -396,6 +396,36 @@ def parse_tool_calls(text):
                 if recovered:
                     tool_calls.append(recovered)
 
+    # Format 3.5: Qwen 2.5 — <tools>{"name": "x", "arguments": {...}}</tools>
+    # Some Qwen 2.5 fine-tunes emit a <tools> wrapper instead of <tool_call>.
+    if not tool_calls:
+        pattern_qwen25 = r'<tools>\s*(.*?)\s*</tools>'
+        for match in re.finditer(pattern_qwen25, text, re.DOTALL):
+            content = match.group(1).strip()
+            remaining = remaining.replace(match.group(0), "", 1)
+            if not content:
+                continue
+            try:
+                call_data = json.loads(content)
+                if isinstance(call_data, list):
+                    for cd in call_data:
+                        if isinstance(cd, dict) and "name" in cd:
+                            tool_calls.append({
+                                "name": cd.get("name", ""),
+                                "arguments": cd.get("arguments", cd.get("parameters", {})),
+                            })
+                elif isinstance(call_data, dict) and "name" in call_data:
+                    tool_calls.append({
+                        "name": call_data.get("name", ""),
+                        "arguments": call_data.get("arguments", call_data.get("parameters", {})),
+                    })
+            except json.JSONDecodeError:
+                recovered = recover_garbled_tool_json(content, text)
+                if recovered:
+                    tool_calls.append(recovered)
+                else:
+                    log(f"  Warning: unrecoverable <tools> JSON: {content[:100]}")
+
     # Format 4: Garbled — no tags at all, but parameter= patterns in raw text
     if not tool_calls:
         # Look for any tool name followed by parameter patterns


### PR DESCRIPTION
## Why

The README targets Mac Max/Ultra (64-128 GB). On a Mac base/Pro 16 GB
five reproducible failures stop the project from working out of the box,
the worst of which silently breaks the "100% offline / 0$/mo" promise.

This branch documents and fixes all five.

## What's broken on 16 GB (and how this branch fixes each)

1. **macOS keychain bug — login screen on every launch even with
   `ANTHROPIC_API_KEY` set.** The launcher's `--bare` flag doesn't
   exist on Claude Code 2.1.76. → Workaround: set `hasCompletedOnboarding`
   in `~/.claude.json`, export `ANTHROPIC_AUTH_TOKEN` alongside
   `ANTHROPIC_API_KEY`, set `DISABLE_LOGIN_COMMAND=1`. Documented +
   automated in the new launchers.

2. **`clean_response` only handled Gemma 4 stop markers** (`<turn|>`,
   `<|turn>`). On any ChatML/Llama 3.x model the special tokens leaked
   into the visible answer (`<|im_end|>`, `<|endoftext|>`, `<|eot_id|>`).
   → Extended the marker list (commit 1).

3. **Claude Code 2.1's "extended thinking" exhausts small models**
   on the first call (the thinking pass), leaving the answer pass with
   no budget → `(No output)`. → Force `--effort low` in the launchers
   (disables the two-step flow). Documented in MAC-BASE-SETUP.md §3.

4. **`parse_tool_calls` didn't recognize Qwen 2.5's `<tools>` wrapper.**
   Qwen 2.5 Coder fine-tunes emit tool calls inside `<tools>...</tools>`
   instead of `<tool_call>` (Qwen 3.5 / generic ChatML). Without the
   parser knowing this, tool calls were returned as plain text and
   Claude Code never executed them. → Added Format 3.5 to the parser
   (commit 4).

5. **(Most serious) Claude Code calls `api.anthropic.com` on startup
   even with `ANTHROPIC_BASE_URL` set.** Confirmed via `lsof`:
   
   claude TCP mac:63057->160.79.104.10:https (ESTABLISHED)


`whois 160.79.104.10` → `OrgName: Anthropic, PBC`.
`dig +short api.anthropic.com` → `160.79.104.10`.

The CLI fires telemetry, statsig feature flags, marketplace
auto-install and autoupdater checks against `api.anthropic.com`
directly, bypassing the configured base URL. **That means setups
following the current README are not actually offline.**

→ Export 4 env vars in the launchers (and document):

CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 DISABLE_AUTOUPDATER=1 CLAUDE_CODE_DISABLE_OFFICIAL_MARKETPLACE_AUTOINSTALL=1 CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1

With these set, `lsof` shows the claude process only connects to
`localhost:4000`. Validated end-to-end.

## Recommended model for 16 GB

`mlx-community/Qwen2.5-Coder-14B-Instruct-4bit`:

- 7.8 GB weights → fits in 16 GB unified memory with no swap
- Tool calls validated end-to-end after Format 3.5 fix
- ~10–15 tok/s generation, ~0.2–0.4 tok/s with cold prefill of the
full Claude Code system prompt (~3000 tokens)

Gemma 4 31B Abliterated (the upstream default) was tested first and
crashes with `kIOGPUCommandBufferCallbackErrorOutOfMemory` on the very
first inference on 16 GB — 18 GB of weights + KV cache simply don't
fit alongside macOS. The MAC-BASE-SETUP.md table has been updated to
reflect this.

## Files

- `proxy/server.py`: stop-marker fix + Format 3.5 parser
- `launchers/Claude Chat.command`: chat-only (`--tools ""`)
- `launchers/Claude Agentico.command`: tools enabled (`--permission-mode auto`)
- `docs/MAC-BASE-SETUP.md`: full PT-BR diagnosis of all 5 failures with
reproducible commands and validation logs

## Test plan

- [x] Server loads `Qwen2.5-Coder-14B-Instruct-4bit` cleanly (~30s)
- [x] Plain `/v1/messages` PT-BR call: clean text, no token leakage,
   `stop_reason=end_turn`
- [x] `/v1/messages` with `tools=[Bash]`: returns `stop_reason=tool_use`
   with `Bash({"command":"pwd"})`
- [x] End-to-end with Claude Code CLI 2.1.76: `--print "Hi"` returns
   `Hello! How can I assist you today?` from the local model
- [x] `lsof -p $CLAUDE_PID` confirms zero connections to
   `api.anthropic.com`, only `localhost:4000`
