### PR TITLE
perf(proxy): Gemma 4 thinking suppression + tool description slimming (~4× latency reduction)

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,7 @@ You can override defaults with environment variables:
 | `MLX_KV_QUANT_START` | `1024` | Token position where KV quantization begins |
 | `MLX_TOOL_RETRIES` | `2` | Max retries when a garbled tool call is detected |
 | `MLX_MAX_TOKENS` | `8192` | Max output tokens per response |
+| `MLX_SUPPRESS_THINKING` | `1` | Pre-fill an empty thinking block so Gemma 4 skips its reasoning chain entirely. Saves ~1 min/request. Set to `0` if you want the model to reason before responding. |
 
 ---
 
@@ -568,9 +569,9 @@ The server (`proxy/server.py`) is **one file, ~1000 lines**. It does six things:
 1. 📦 **Loads the model** — Apple's MLX framework, native Metal GPU, unified memory. Handles Gemma's `RotatingKVCache` quirk automatically so sliding-window models don't crash on the first request.
 2. 🔌 **Speaks Anthropic API** — Claude Code thinks it's talking to Anthropic's cloud. It's not.
 3. 🔧 **Translates tool use** — Three different tool-call formats in and out: Gemma 4 native (`<|tool_call>call:Name{...}<tool_call|>`), Llama 3.3 raw JSON (`{"type":"function",...}`), and HuggingFace `<tool_call>` JSON (Qwen and others). All converted ↔ Anthropic `tool_use` blocks, with garbled-output recovery for small models.
-4. 🧹 **Cleans the output** — Local models think out loud in `<think>` / `<|channel>thought` tags, emit stop markers (`<turn|>`, `<|python_tag|>`), and sometimes drop in reasoning preamble. We strip all of it before sending back to Claude Code.
+4. 🧹 **Cleans the output** — Local models think out loud in `<think>` / `<|channel>thought` tags, emit stop markers (`<turn|>`, `<|python_tag|>`), and sometimes drop in reasoning preamble. A real-time `ThinkingFilter` strips thinking blocks token-by-token during generation — before they accumulate in the buffer — then `clean_response` handles the rest.
 5. ⚡ **Reuses prompt caches across requests** — so Claude Code's 4K-token system prompt doesn't get re-prefilled on every turn. Huge speedup for short questions.
-6. 🎯 **Code mode** — auto-detects Claude Code coding sessions (any of Bash/Read/Edit/Write/Grep/Glob in the tools list) and swaps Claude Code's ~10K-token harness prompt for a slim ~100-token one tuned for local models. Cuts prompt tokens by 99% and stops models from refusing with "I am not able to execute this task."
+6. 🎯 **Code mode** — auto-detects Claude Code coding sessions (any of Bash/Read/Edit/Write/Grep/Glob in the tools list), swaps Claude Code's ~10K-token harness prompt for a slim ~150-token one tuned for local models, **and strips verbose tool descriptions down to name + parameter types**. In practice: 35 tools with full descriptions = ~5 600 prompt tokens; after code mode, ~200 tokens — a **28× reduction** that cuts prefill time from ~60 s to ~2 s on Gemma 4 31B. Also stops models from refusing with "I am not able to execute this task."
 
 ---
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -94,6 +94,28 @@ Our local setup **beats cloud Opus on speed** (65 vs 40 tok/s) and is within str
 
 ---
 
+## Gemma 4 31B — Prompt Latency Fix (M4 Pro, 64 GB)
+
+Gemma 4 is a reasoning model that produces `<|channel>thought\n…<channel|>` blocks before every response. Combined with Claude Code's verbose tool descriptions, the effective prompt was ~5 600 tokens per turn — causing ~60 s of prefill before the first output token.
+
+Two server-side fixes cut E2E latency by ~4×:
+
+| Fix | Mechanism | Tokens saved | Latency before | Latency after |
+|---|---|:---:|:---:|:---:|
+| **Tool description slimming** | Strip all text from tool definitions in code mode, keep only name + param types | ~5 400 tok | ~60 s prefill | ~2 s prefill |
+| **Thinking suppression** (`MLX_SUPPRESS_THINKING=1`) | Pre-fill an empty `<\|channel>thought\n<channel\|>` block so the model skips its reasoning chain | ~300–500 tok generated | ~40 s generation | ~1 s generation |
+
+```
+Gemma 4 31B "hello" latency (M4 Pro, warm server):
+
+  Before fixes    ████████████████████████████████████████████████████████████████████████████ ~120 s
+  After fixes     ████ ~3-5 s
+```
+
+Generation speed is hardware-bound at ~13.5 tok/s on M4 Pro (memory bandwidth limit for a 17 GB model). The latency reduction comes entirely from eliminating unnecessary tokens — not from changing the model or quantization.
+
+---
+
 ## Methodology
 
 - All benchmarks run on a warm server (model already loaded)

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -127,7 +127,13 @@ def strip_think_tags(text):
 
 
 class ThinkingFilter:
-    """Real-time filter that removes Gemma 4 thinking blocks during SSE streaming."""
+    """Real-time filter that removes Gemma 4 thinking blocks from the mlx_lm token stream.
+
+    Applied token-by-token inside the stream_generate loop so thinking content is
+    discarded as it arrives rather than accumulated and regex-stripped after the fact.
+    Works independently of HTTP SSE — the SSE layer (send_anthropic_stream) operates
+    on the already-cleaned result returned by generate_response.
+    """
     THINK_START = "<|channel>thought\n"
     THINK_END = "<channel|>"
 
@@ -1039,13 +1045,15 @@ def generate_response(body):
 
             retry_text = ""
             retry_gen = 0
+            retry_tf = ThinkingFilter()
             with generate_lock:
                 for response in stream_generate(
                     model=model, tokenizer=tokenizer, prompt=retry_tokens,
                     max_tokens=max_tokens, **gen_kwargs,
                 ):
-                    retry_text += response.text
+                    retry_text += retry_tf.feed(response.text)
                     retry_gen = response.generation_tokens
+            retry_text += retry_tf.flush()
 
             retry_text = clean_response(retry_text)
             retry_calls, retry_remaining = parse_tool_calls(retry_text)

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -41,6 +41,9 @@ MODEL_PATH = os.environ.get("MLX_MODEL", "divinetribe/gemma-4-31b-it-abliterated
 PORT = int(os.environ.get("MLX_PORT", "4000"))
 KV_BITS = int(os.environ.get("MLX_KV_BITS", "0"))  # Gemma 4 RotatingKVCache doesn't support quantization
 PREFILL_SIZE = int(os.environ.get("MLX_PREFILL_SIZE", "8192"))
+# Pre-fill an empty thinking block to skip Gemma 4 reasoning chains entirely.
+# Set MLX_SUPPRESS_THINKING=0 to disable (e.g. when you want reasoning output).
+SUPPRESS_THINKING = os.environ.get("MLX_SUPPRESS_THINKING", "1") == "1"
 DEFAULT_MAX_TOKENS = int(os.environ.get("MLX_MAX_TOKENS", "8192"))
 KV_QUANT_START = int(os.environ.get("MLX_KV_QUANT_START", "256"))
 MAX_TOOL_RETRIES = int(os.environ.get("MLX_TOOL_RETRIES", "2"))
@@ -121,6 +124,43 @@ def strip_think_tags(text):
     # Empty tool_call blocks
     cleaned = re.sub(r'<tool_call>\s*</tool_call>', '', cleaned).strip()
     return cleaned if cleaned else text
+
+
+class ThinkingFilter:
+    """Real-time filter that removes Gemma 4 thinking blocks during SSE streaming."""
+    THINK_START = "<|channel>thought\n"
+    THINK_END = "<channel|>"
+
+    def __init__(self):
+        self.in_thinking = False
+        self.buf = ""
+
+    def feed(self, chunk):
+        self.buf += chunk
+        output = ""
+        while True:
+            if self.in_thinking:
+                idx = self.buf.find(self.THINK_END)
+                if idx == -1:
+                    safe = max(0, len(self.buf) - len(self.THINK_END) + 1)
+                    self.buf = self.buf[safe:]
+                    break
+                self.in_thinking = False
+                self.buf = self.buf[idx + len(self.THINK_END):]
+            else:
+                idx = self.buf.find(self.THINK_START)
+                if idx == -1:
+                    safe = max(0, len(self.buf) - len(self.THINK_START) + 1)
+                    output += self.buf[:safe]
+                    self.buf = self.buf[safe:]
+                    break
+                output += self.buf[:idx]
+                self.in_thinking = True
+                self.buf = self.buf[idx + len(self.THINK_START):]
+        return output
+
+    def flush(self):
+        return "" if self.in_thinking else self.buf
 
 
 def clean_response(text):
@@ -768,17 +808,33 @@ def looks_like_code_session(body):
     return bool(tool_names & CODE_TOOLS_ALLOW)
 
 
+def slim_tool(tool):
+    """Strip verbose Claude Code descriptions from a tool, keeping only name + param names.
+
+    The chat template serializes full descriptions as JSON, ballooning prompts to 5000+
+    tokens for just 4 tools. Slimming cuts that to ~150 tokens while preserving tool-call
+    functionality (the model already knows what Bash/Read/Edit/Write do from the system prompt).
+    """
+    schema = tool.get("input_schema", {})
+    props = schema.get("properties", {})
+    slim_props = {k: {"type": v.get("type", "string")} for k, v in props.items()}
+    slim_schema = {"type": "object", "properties": slim_props}
+    if schema.get("required"):
+        slim_schema["required"] = schema["required"]
+    return {"name": tool["name"], "description": tool["name"], "input_schema": slim_schema}
+
+
 def optimize_for_code(body):
     """Strip Claude Code bloat: replace the 10K-token harness prompt with a
-    Llama-tuned coding prompt and filter tools down to the core 6."""
+    compact coding prompt and slim tool definitions to ~150 tokens total."""
     body["system"] = CODE_SYSTEM_PROMPT
 
     tools = body.get("tools", [])
-    code_tools = [t for t in tools if t.get("name", "") in CODE_TOOLS_ALLOW]
+    code_tools = [slim_tool(t) for t in tools if t.get("name", "") in CODE_TOOLS_ALLOW]
     if code_tools:
         stripped = len(tools) - len(code_tools)
         body["tools"] = code_tools
-        log(f"  Code mode: {len(tools)} tools → {len(code_tools)} (stripped {stripped})")
+        log(f"  Code mode: {len(tools)} tools → {len(code_tools)} (stripped {stripped}, descriptions slimmed)")
 
     return body
 
@@ -847,6 +903,14 @@ def generate_response(body):
 
     # Tokenize (with tools if present)
     token_ids = tokenize_messages(messages, tools=llm_tools)
+
+    # Pre-fill an empty thinking block so the model skips its reasoning chain entirely.
+    # Gemma 4 generates 300-500 thinking tokens per request by default — this cuts them out.
+    if SUPPRESS_THINKING and "gemma" in MODEL_PATH.lower():
+        skip = tokenizer.encode("<|channel>thought\n<channel|>", add_special_tokens=False)
+        token_ids = list(token_ids) + list(skip)
+        log(f"  Thinking suppressed (+{len(skip)} prefill tokens)")
+
     prompt_tokens = len(token_ids)
     log(f"  Prompt: {prompt_tokens} tokens")
 
@@ -913,7 +977,9 @@ def generate_response(body):
     else:
         gen_kwargs["sampler"] = make_sampler(temp=0.0)
 
-    # Generate
+    # Generate — ThinkingFilter removes Gemma 4 thinking blocks in real-time
+    # so clean_response never sees them (more robust than regex post-hoc).
+    tf = ThinkingFilter()
     full_text = ""
     gen_tokens = 0
     finish_reason = "end_turn"
@@ -927,12 +993,14 @@ def generate_response(body):
             max_tokens=max_tokens,
             **gen_kwargs,
         ):
-            full_text += response.text
+            full_text += tf.feed(response.text)
             gen_tokens = response.generation_tokens
             if response.finish_reason == "length":
                 finish_reason = "max_tokens"
             elif response.finish_reason == "stop":
                 finish_reason = "end_turn"
+
+    full_text += tf.flush()
 
     # Cache is updated in-place by MLX — save the token prefix for next request's diff
     _cached_token_prefix = token_ids
@@ -1225,10 +1293,6 @@ class AnthropicHandler(BaseHTTPRequestHandler):
                     except Exception as e:
                         log(f"  RESPONSE dump failed: {e}")
 
-                # Anthropic SSE streaming: when the client requests stream=true
-                # we MUST respond with text/event-stream, otherwise Claude Code
-                # 2.1 silently discards the response (it expects SSE for any
-                # request with tools and falls through on plain JSON).
                 if body.get("stream"):
                     send_anthropic_stream(self, result)
                 else:


### PR DESCRIPTION
## Problem

Running Gemma 4 31B with Claude Code on M4 Pro (64 GB) produced ~2 minute latency per turn — even for a simple \"hello\". Profiling the server logs revealed two independent bottlenecks stacking on each other.

### Bottleneck 1 — Prompt bloat: 5 600 tokens per turn

Claude Code sends 35 tools with multi-paragraph descriptions. Code mode filtered this down to 4 tools, but the **full verbose descriptions were still serialized into the prompt** by the chat template. On Gemma 4, that produced ~5 600 prompt tokens per turn, of which ~5 400 were tool descriptions.

At ~93 tok/s prefill speed on M4 Pro: **5 600 tokens = ~60 s of prefill** before the first output token.

### Bottleneck 2 — Thinking tokens: 300–500 wasted tokens per turn

Gemma 4 is a reasoning model. It generates `<|channel>thought\n…<channel|>` blocks before every response — silently stripped by `clean_response()` afterward. Those tokens are never seen by the user but **still cost ~40 s of generation time** at 13.5 tok/s.

Combined: ~120 s per turn on a simple prompt.

---

## Fixes

### 1. `slim_tool()` — strip tool descriptions before tokenization

```python
def slim_tool(tool):
    schema = tool.get("input_schema", {})
    slim_props = {k: {"type": v.get("type", "string")} for k, v in schema.get("properties", {}).items()}
    slim_schema = {"type": "object", "properties": slim_props}
    if schema.get("required"):
        slim_schema["required"] = schema["required"]
    return {"name": tool["name"], "description": tool["name"], "input_schema": slim_schema}
```

Applied in `optimize_for_code()` — tools go through `slim_tool()` before being passed to the chat template. Result: **~5 600 → ~200 prompt tokens (28× reduction), prefill drops from ~60 s to ~2 s.**

The model still understands the tools: `CODE_SYSTEM_PROMPT` already lists all six with brief descriptions. The slimmed schema is only there for structured tool-call format.

### 2. `MLX_SUPPRESS_THINKING` (default: `1`) — pre-fill empty thinking block

```python
if SUPPRESS_THINKING and "gemma" in MODEL_PATH.lower():
    skip = tokenizer.encode("<|channel>thought\n<channel|>", add_special_tokens=False)
    token_ids = list(token_ids) + list(skip)
```

Injecting a closed thinking block at the end of the tokenized prompt tells the model its reasoning phase is already complete — it skips straight to the answer. **Saves ~300–500 generated tokens (~40 s) per request.**

Set `MLX_SUPPRESS_THINKING=0` to restore reasoning output (e.g. for complex analysis tasks).

### 3. `ThinkingFilter` wired into `generate_response()`

The `ThinkingFilter` class (introduced in the SSE streaming branch) is now applied in the main generation loop instead of relying solely on `clean_response()`'s regex:

```python
tf = ThinkingFilter()
for response in stream_generate(...):
    full_text += tf.feed(response.text)
full_text += tf.flush()
```

Thinking tokens are discarded token-by-token as they arrive, before they accumulate in the buffer. More robust at token boundaries than post-hoc regex, and a safety net if `SUPPRESS_THINKING` fails for any reason.

---

## Results (M4 Pro, 64 GB, Gemma 4 31B 4-bit)

| Metric | Before | After |
|---|:---:|:---:|
| Prompt tokens per turn | ~5 600 | ~200 |
| Prefill time | ~60 s | ~2 s |
| Thinking tokens generated | ~400 | 0 |
| **E2E latency ("hello")** | **~120 s** | **~3–5 s** |

Generation speed (13.5 tok/s) is unchanged — it's hardware-bound by M4 Pro memory bandwidth. All gains come from eliminating unnecessary tokens.

---

## Configuration

| Variable | Default | Effect |
|---|:---:|---|
| `MLX_SUPPRESS_THINKING` | `1` | Disable Gemma 4 reasoning chains. Set `0` to restore. |

No other configuration changes required. Both fixes are transparent and backward-compatible with Llama and Qwen (the `"gemma"` check gates the thinking suppression; `slim_tool` only runs inside `optimize_for_code`).