### PR TITLE
fix: stop generation on the tokenizer's real EOS, and tolerate empty env ints

### DIFF
--- a/proxy/server.py
+++ b/proxy/server.py
@@ -37,16 +37,29 @@ from mlx_lm.models.cache import make_prompt_cache
 
 # ─── Configuration ───────────────────────────────────────────────────────────
 
+def env_int(name, default):
+    """int() an env var, treating unset *and empty* as "use the default".
+
+    os.environ.get(name, default) only falls back when the key is absent, not
+    when it is present-but-empty. The launchers pass values through
+    ensure_mlx_server() as MLX_KV_BITS="${MLX_KV_BITS:-}", which exports an
+    empty string when the caller hasn't set one — so int("") raised ValueError
+    and the server died before it ever bound the port.
+    """
+    raw = os.environ.get(name, "")
+    return int(raw) if raw.strip() else default
+
+
 MODEL_PATH = os.environ.get("MLX_MODEL", "divinetribe/gemma-4-31b-it-abliterated-4bit-mlx")
-PORT = int(os.environ.get("MLX_PORT", "4000"))
-KV_BITS = int(os.environ.get("MLX_KV_BITS", "0"))  # Gemma 4 RotatingKVCache doesn't support quantization
-PREFILL_SIZE = int(os.environ.get("MLX_PREFILL_SIZE", "8192"))
+PORT = env_int("MLX_PORT", 4000)
+KV_BITS = env_int("MLX_KV_BITS", 0)  # Gemma 4 RotatingKVCache doesn't support quantization
+PREFILL_SIZE = env_int("MLX_PREFILL_SIZE", 8192)
 # Pre-fill an empty thinking block to skip Gemma 4 reasoning chains entirely.
 # Set MLX_SUPPRESS_THINKING=0 to disable (e.g. when you want reasoning output).
 SUPPRESS_THINKING = os.environ.get("MLX_SUPPRESS_THINKING", "1") == "1"
-DEFAULT_MAX_TOKENS = int(os.environ.get("MLX_MAX_TOKENS", "8192"))
-KV_QUANT_START = int(os.environ.get("MLX_KV_QUANT_START", "256"))
-MAX_TOOL_RETRIES = int(os.environ.get("MLX_TOOL_RETRIES", "2"))
+DEFAULT_MAX_TOKENS = env_int("MLX_MAX_TOKENS", 8192)
+KV_QUANT_START = env_int("MLX_KV_QUANT_START", 256)
+MAX_TOOL_RETRIES = env_int("MLX_TOOL_RETRIES", 2)
 # Browser mode: strip Claude Code bloat, keep only MCP tools
 BROWSER_MODE = os.environ.get("MLX_BROWSER_MODE", "0") == "1"
 # Code mode: auto-detect Claude Code coding sessions and replace the huge harness
@@ -97,6 +110,26 @@ def load_model():
     if not getattr(tokenizer, 'chat_template', None):
         tokenizer.chat_template = GEMMA4_CHAT_TEMPLATE
         log("Injected Gemma 4 chat template")
+
+    # Some quant repos ship a generation_config.json whose eos_token_id
+    # disagrees with tokenizer_config.json's eos_token. mlx-lm seeds its stop
+    # set (tokenizer.eos_token_ids) from generation_config, so when the chat
+    # template actually terminates turns with the *other* token, generation
+    # never stops: the real stop token is decoded as ordinary text and every
+    # request runs to max_tokens.
+    #
+    # Seen on divinetribe/Hermes-4-14B-abliterated-4bit-mlx, whose
+    # generation_config says 151643 (<|endoftext|>) while its template emits
+    # 151645 (<|im_end|>) — 503s and 4096 tokens for what should be a 20-token
+    # tool call. Unioning the two is safe: a token that is EOS in either config
+    # is never a legitimate mid-sequence token.
+    _tok_eos = getattr(tokenizer, "eos_token_id", None)
+    if _tok_eos is not None:
+        _stop_set = set(getattr(tokenizer, "eos_token_ids", None) or set())
+        if _tok_eos not in _stop_set:
+            tokenizer.eos_token_ids = _stop_set | {_tok_eos}
+            log(f"Added eos_token_id {_tok_eos} to stop set (was {_stop_set or set()})")
+
     elapsed = time.time() - t0
     log(f"Model loaded in {elapsed:.1f}s")
 


### PR DESCRIPTION
Two independent bugs, each of which stops a fresh install from working. Found while bringing up Hermes 4 14B on an M5 (base, 32 GB); the second one is not model-specific and affects several of the shipped launchers on any clean machine.

---

## 1. Runaway generation when `generation_config.json` disagrees about EOS

mlx-lm seeds its stop set (`tokenizer.eos_token_ids`) from `generation_config.json`. If a quant repo's `generation_config` names a different token than the one its chat template actually emits, the real stop token gets decoded as ordinary text and generation never terminates — **every request runs to `max_tokens`**.

On `divinetribe/Hermes-4-14B-abliterated-4bit-mlx`:

| File | Field | Value |
|---|---|---|
| `generation_config.json` | `eos_token_id` | **151643** (`<\|endoftext\|>`) |
| `tokenizer_config.json` | `eos_token` | **151645** (`<\|im_end\|>`) |
| `chat_template.jinja` | turn terminator | `<\|im_end\|>` (all 7 turn types) |

Reproducible below the server, straight through mlx-lm:

```python
m, t = load("divinetribe/Hermes-4-14B-abliterated-4bit-mlx")
# t.eos_token_id  -> 151645     (correct)
# t.eos_token_ids -> {151643}   (what generation actually stops on)
ids = t.apply_chat_template([{"role":"user","content":"Say hello in exactly five words."}],
                            add_generation_prompt=True)
for r in stream_generate(model=m, tokenizer=t, prompt=ids, max_tokens=300):
    ...
# finish_reason=length  tokens=300
# "Hello, how may I assist you today?<|im_end|>\nI'm Hermes, created by Nous
#  Research. How can I help you?<|im_end|>\nI'm Hermes, created by ..."
```

The model emits `<|im_end|>` in the right place every time — it just isn't in the stop set, so it becomes text and the model keeps going.

**This is easy to misdiagnose as slow hardware.** Tool calls still parse, the response still returns `stop_reason: "tool_use"`, nothing raises. It just costs 4096 tokens / 503s for what should be a 20-token tool call.

`load_model()` now unions `tokenizer.eos_token_id` into `eos_token_ids`. Safe by construction: a token that is EOS under *either* config is never a legitimate mid-sequence token. Models whose configs already agree are untouched (the branch is skipped and nothing is logged).

## 2. `int("")` ValueError on startup, from the launchers' own env vars

`ensure_mlx_server()` in `launchers/lib/claude-local-common.sh` passes:

```bash
MLX_KV_BITS="${MLX_KV_BITS:-}" \
MLX_KV_QUANT_START="${MLX_KV_QUANT_START:-}" \
```

which exports an **empty string** when the caller hasn't set one. `server.py` read those with `int(os.environ.get("MLX_KV_BITS", "0"))` — but `.get()`'s default only fires when the key is *absent*, not when it's present-but-empty. So `int("")` raises and the server dies before it ever binds :4000:

```
File ".../server.py", line 42, in <module>
    KV_BITS = int(os.environ.get("MLX_KV_BITS", "0"))
ValueError: invalid literal for int() with base 10: ''
```

The launcher then reports the misleading downstream symptom:

```
  ERROR: MLX server failed to respond on port 4000 within 120s
```

Every launcher that calls `ensure_mlx_server()` without pre-setting those two vars hits this on a clean machine — **Gemma 4 Code**, **Llama 70B**, **Claude Local**. `Claude Chat` escapes it only because it happens to `export MLX_KV_BITS="${MLX_KV_BITS:-4}"` for unrelated reasons.

Adds `env_int()`, which treats unset and empty/whitespace alike as "use the default", and routes the six numeric env vars through it. Fixing it at the parsing boundary rather than in the shell lib keeps the server robust against any caller.

---

## Verification

M5 (base tier, 32 GB, fanless), `mlx 0.32.0` / `mlx-lm 0.31.3`, Python 3.12.13, model `divinetribe/Hermes-4-14B-abliterated-4bit-mlx`.

`scripts/test_mlx_server.py`, before: every test exceeds the harness's 120s client timeout while the server generates for ~503s per request.

After:

```
RESULTS: 13 passed, 1 failed out of 14 tests
  ✗ Simple Bash command — Expected tool 'Bash' but got: ['Glob']
  ✓ Create directory with mkdir
  ✓ Read a file
  ✓ Complex Bash with pipes
  ✓ Edit a file
  ✓ Multi-tool: find then read
  ✓ Rapid-fire #1..#5
  ✓ Calendar Step 1: Create month folders
  ✓ Calendar Step 2: Delete all months except September
  ✓ Calendar Step 3: Verify remaining folders
```

Per-turn latency ~503s → **3–18s**; output ~4096 tokens → **20–53 tokens**.

The one remaining failure is a test-side assertion artifact rather than a regression: for *"List the files in /tmp"* the model answers `Glob({pattern: "/tmp/*"})`, which is a reasonable tool choice, but the test hard-codes `expect_tool="Bash"`. Happy to loosen that assertion in this PR if you'd prefer — left alone for now since it's a separate judgement call.

Fix 2 was verified against the exact original failure by starting the server with `MLX_KV_BITS=` explicitly empty, plus a small table check of `env_int` over unset / empty / whitespace / real values.

Both fixes are in `proxy/server.py`; no launcher or script behaviour changes.
