### PR TITLE
fix: parse bare top-level JSON tool calls (Qwen 2.5 Coder: 0/12 → 14/14)

### DIFF
--- a/proxy/server.py
+++ b/proxy/server.py
@@ -554,6 +554,56 @@ def parse_tool_calls(text):
                     f"{', '.join(t['name'] for t in extracted_in_block)}"
                 )
 
+    # Format 3.7: bare top-level JSON with no wrapper at all —
+    #   {"name": "Bash", "arguments": {"command": "ls /tmp"}}
+    # Qwen 2.5 Coder emits exactly this: no <tool_call> tags, no <tools>, no
+    # markdown fence, just the object. Formats 3.5/3.6 already cover the
+    # wrapped and fenced variants of the same shape, so this is the last one.
+    # Without it Qwen 2.5 Coder scores 0/12 on scripts/test_mlx_server.py —
+    # every call is well-formed and every call is invisible to the parser.
+    # Re-prompting doesn't rescue it either: the retry explicitly asks for
+    # <tool_call> tags and the model declines, and recover_garbled_tool_json
+    # never fires because the JSON was never garbled.
+    #
+    # Same back-to-back handling as 3.6 (raw_decode in a loop) for models that
+    # emit several sequential calls without an array. Runs only after every
+    # tagged format has failed, so an explicit wrapper always takes priority.
+    if not tool_calls:
+        stripped = text.strip()
+        if stripped.startswith("{"):
+            decoder_bare = json.JSONDecoder()
+            extracted_bare = []
+            pos = 0
+            while pos < len(stripped):
+                while pos < len(stripped) and stripped[pos] in " \t\n\r,":
+                    pos += 1
+                if pos >= len(stripped) or stripped[pos] != "{":
+                    break
+                try:
+                    obj, end_pos = decoder_bare.raw_decode(stripped, pos)
+                except json.JSONDecodeError:
+                    break
+                pos = end_pos
+                if not isinstance(obj, dict):
+                    continue
+                name = obj.get("name") or obj.get("tool")
+                args = (
+                    obj.get("arguments")
+                    or obj.get("parameters")
+                    or obj.get("args")
+                    or obj.get("input")
+                )
+                if name and isinstance(args, dict):
+                    extracted_bare.append({"name": name, "arguments": args})
+            if extracted_bare:
+                tool_calls.extend(extracted_bare)
+                # The whole message was the tool call; nothing survives as prose.
+                remaining = stripped[pos:].strip()
+                log(
+                    f"  Bare JSON tool calls: "
+                    f"{', '.join(t['name'] for t in extracted_bare)}"
+                )
+
     # Format 4: Garbled — no tags at all, but parameter= patterns in raw text
     if not tool_calls:
         # Look for any tool name followed by parameter patterns


### PR DESCRIPTION
`mlx-community/Qwen2.5-Coder-14B-Instruct-4bit` — the model both `Claude Agentico.command` and `Claude Chat.command` ship with — scores **0 passed / 12** on `scripts/test_mlx_server.py` on a clean checkout. Every single test fails with `Expected a tool call but got none`.

It isn't the model. It emits textbook-correct tool calls, just with no wrapper:

```json
{
  "name": "Bash",
  "arguments": {
    "command": "ls /tmp",
    "description": "List files in /tmp directory"
  }
}
```

`parse_tool_calls()` covers the Gemma-native `<|tool_call>…<tool_call|>` form, `<tool_call>{…}</tool_call>`, `<tools>{…}</tools>`, markdown-fenced JSON, and the tagless `<parameter=…>` recovery path — but not a bare top-level object. So every one of those calls is invisible.

Nothing downstream catches it either:

- The retry path **does** fire (the text contains `"name":`, which is in `tool_intent_phrases`), re-prompts twice explicitly demanding `<tool_call>` tags, and Qwen declines both times.
- `recover_garbled_tool_json` never helps, because the JSON was never garbled — it parses perfectly on the first try.

From the server log:

```
Tool intent detected but parser missed it. Raw text (400 chars): '{\n  "name": "Bash",\n  "arguments": {\n    "command": "ls /tmp", ...
Retry 1/2: tool intent detected but no valid tool call, re-prompting
Retry 1 failed, still no valid tool call
Retry 2/2: tool intent detected but no valid tool call, re-prompting
Retry 2 failed, still no valid tool call
```

## The change

Adds **Format 3.7**, modelled directly on the existing Format 3.6 (markdown-fenced) handler: `json.JSONDecoder().raw_decode()` in a loop so back-to-back objects are picked up, with the same `name`/`tool` and `arguments`/`parameters`/`args`/`input` key aliases.

It is guarded by `if not tool_calls:` and sits after every tagged format, so an explicit wrapper always wins — it only runs as a last resort, immediately before the `<parameter=…>` garbled-recovery path.

## Verification

M5 (base, 32 GB), Python 3.12.13, mlx 0.32.0, mlx-lm 0.31.3. Rebased on current `main` (0a2f3f5), so this includes #41 and your updated Glob assertion.

**Qwen 2.5 Coder 14B**

| | Result |
|---|---|
| before | 0 passed / 12 — ×3 runs |
| after | **14 passed / 14** — ×2 runs on the current harness (plus ×2 on the pre-`18e8c89` harness) |

**Gemma 4 12B — regression check** (`divinetribe/gemma-4-12B-it-abliterated-4bit-mlx-text`)

| | Result |
|---|---|
| before | 8, 8, 7 / 12 |
| after | 8, 8 / 12 — unchanged |

Gemma logs **zero** `Bare JSON tool calls` lines, confirming the new branch never fires for a model that already has a working format.

**Unit coverage** — 9 cases over `parse_tool_calls` directly:

- bare single object, pretty-printed multi-line, `"parameters"` alias, back-to-back objects
- no regression: tagged `<tool_call>` still wins, fenced ```json still works, ordinary prose untouched, non-tool JSON (`{"foo": 1}`) ignored, malformed JSON handled without raising

## Note

This is independent of #42 — that one is about `MLX_KV_BITS`, and I've since posted a correction there narrowing its scope after testing Qwen and Gemma (the KV problem turned out to be specific to Hermes 4 14B; Agentico's default is fine). This PR stands on its own.

Worth mentioning that the two interact in one direction: with Qwen floored at 0/12, any KV comparison on it was undecidable, since both arms sit on the floor. Only after this fix could I measure that Qwen is genuinely unaffected by 4-bit KV (14/14 either way).
