### PR TITLE
fix: accept Gemma 4's collapsed <tool_call:Name{...} opener (7/14 -> 14/14)

### DIFF
--- a/proxy/server.py
+++ b/proxy/server.py
@@ -357,14 +357,28 @@ def parse_tool_calls(text):
 
     # Format 0: Gemma 4 native — <|tool_call>call:Name{key:<|"|>val<|"|>}<tool_call|>
     # Parse BEFORE replacing escape tokens — use <|"|> as reliable value delimiters
-    gemma4_pattern = r'<\|tool_call>(.*?)<tool_call\|>'
+    #
+    # Three spellings of the opener turn up in practice. The documented one is
+    # <|tool_call>call:Name{...}. Some models drop the call: prefix. And
+    # abliterated Gemma 4 31B collapses the whole marker to <tool_call:Name{...},
+    # which is the SAME grammar — same <|"|> value delimiters, same <tool_call|>
+    # closer, only the opening marker differs — so it is one alternation here
+    # rather than a new format further down.
+    #
+    # That third spelling cost 6 of 14 on scripts/test_mlx_server.py with
+    # divinetribe/gemma-4-31b-it-abliterated-4bit-mlx. Every call was well
+    # formed, every call was invisible, and the retry path can't rescue it
+    # because it asks for <tool_call> tags the model has already decided against.
+    # Some also emit a stray > after the closing brace; the body regex tolerates
+    # it because re.match doesn't have to consume the whole string.
+    gemma4_pattern = r'(?:<\|tool_call>|<tool_call:)(.*?)<tool_call\|>'
     gemma4_matches = list(re.finditer(gemma4_pattern, text, re.DOTALL))
     if gemma4_matches:
         remaining = text
         for match in gemma4_matches:
             remaining = remaining.replace(match.group(0), "", 1)
             content = match.group(1).strip()
-            name_m = re.match(r'call:([\w.]+)\{(.*)\}', content, re.DOTALL)
+            name_m = re.match(r'(?:call:)?([\w.]+)\s*\{(.*)\}', content, re.DOTALL)
             if not name_m:
                 log(f"  Gemma4 no name match: {content[:80]}")
                 continue


### PR DESCRIPTION
Same shape as #43, different model. `divinetribe/gemma-4-31b-it-abliterated-4bit-mlx` scores **7-8 passed / 14** on `scripts/test_mlx_server.py`, and every one of the failures is a well formed tool call the parser can't see.

## What the model actually emits

Captured verbatim off the server, `repr()` so the delimiters are visible:

```
'<tool_call:Bash{command:<|"|>echo \'test 1\'<|"|>}><tool_call|>'
'<tool_call:Bash{command:<|"|>mkdir -p /tmp/test_mlx_calendar<|"|>}<tool_call|>'
'<tool_call:Edit{file_path:<|"|>/tmp/test_edit.txt<|"|>,new_string:<|"|>goodbye<|"|>}<tool_call|>'
```

Format 0 expects the documented spelling:

```
<|tool_call>call:Bash{command:<|"|>ls /tmp<|"|>}<tool_call|>
```

The abliterated 31B collapses `<|tool_call>call:` down to `<tool_call:`. **Everything after the opener is identical** — same `<|"|>` value delimiters, same `<tool_call|>` closer, same `Name{...}` body. Only the opening marker differs, so this is one alternation in the existing pattern rather than a new format block further down.

Nothing downstream catches it, for the same reason as #43: the retry path fires, re-prompts twice explicitly asking for `<tool_call>` tags, and the model declines both times, because as far as it's concerned it already emitted a tool call.

## The change

Two lines:

- `gemma4_pattern` opener becomes `(?:<\|tool_call>|<tool_call:)`
- the body regex makes `call:` optional, since it's now consumed by the opener in one branch and absent in the other

Some responses also carry a stray `>` after the closing brace (`}><tool_call|>`). That needs no handling — `re.match` doesn't have to consume the whole string, and the greedy `(.*)\}` backtracks to the last brace either way.

## Verification

`scripts/test_mlx_server.py`, `divinetribe/gemma-4-31b-it-abliterated-4bit-mlx`, fresh server per run:

| | Result |
|---|---|
| before | 7, 7, 8, 8 / 14 |
| after | **14, 14, 14 / 14** |

All 6 remaining failures were this single shape.

**Unit coverage** — 12 cases over `parse_tool_calls` directly. The first three are the verbatim strings above, not constructed to fit the regex:

- collapsed opener with the stray `>`, without it, and with multiple arguments
- no regression: documented opener with `call:`, documented opener without `call:`, values containing quotes and braces, two calls in one response
- no regression: tagged `<tool_call>` JSON still wins, bare JSON from #43 still parses, ordinary prose untouched, prose mentioning `<tool_call:` with no closer ignored, non-tool JSON (`{"foo": 1}`) ignored

## Note

Independent of #44 — that one is prefill memory, elsewhere in the same file. Both branch off `19c5113` and neither touches the other's lines, so they merge in either order.

Tested on M5 Max / 128GB, mlx 0.31.1, mlx-lm 0.31.2, Python 3.12.13.
