### PR TITLE
fix: trim prompt cache by .offset, not .step (#46)

### DIFF
--- a/proxy/server.py
+++ b/proxy/server.py
@@ -981,11 +981,18 @@ def generate_response(body, on_start=None, on_text=None):
     if cache_hit_len >= len(token_ids):
         cache_hit_len = len(token_ids) - 1
 
+    # .offset is the live token count; .step is a fixed 256-token allocation
+    # increment. Reading .step made trim_amount negative for any prefix longer
+    # than 256 tokens, so the trim never ran and the cache kept the previous
+    # session's KV state (issue #46). Caches without .offset can't be trimmed
+    # safely at all, so fall through to a full prefill instead of guessing.
+    cache_offset = getattr(_prompt_cache[0], "offset", None) if _prompt_cache else None
+    if cache_hit_len > 0 and cache_offset is None:
+        log("  Cache has no offset (untrimmable type) — full prefill")
+        cache_hit_len = 0
+
     if cache_hit_len > 0:
         # Trim cache back to the shared prefix, then only prefill the delta
-        #cache_offset = _prompt_cache[0].offset  # total tokens in cache (prompt + gen)
-        # Try .step instead of .offset
-        cache_offset = _prompt_cache[0].step if hasattr(_prompt_cache[0], 'step') else 0
         trim_amount = cache_offset - cache_hit_len
         if trim_amount > 0:
             for c in _prompt_cache:
@@ -1057,6 +1064,15 @@ def generate_response(body, on_start=None, on_text=None):
 
     # Cache is updated in-place by MLX — save the token prefix for next request's diff
     _cached_token_prefix = token_ids
+
+    # An empty completion straight after a cache hit is almost always corrupt
+    # KV state, not a real answer. Say so, and drop the cache so the next
+    # request self-heals with a clean prefill instead of failing silently.
+    if cache_hit_len > 0 and not full_text.strip():
+        log(f"  WARNING: empty completion after a {cache_hit_len}-token cache hit "
+            f"— discarding prompt cache (see issue #46)")
+        _prompt_cache = None
+        _cached_token_prefix = None
 
     elapsed = time.time() - t0
     tps = gen_tokens / elapsed if elapsed > 0 else 0


### PR DESCRIPTION
Fixes #46.

`KVCache.step` is a fixed 256-token allocation increment, not the number of tokens held in the cache. Reading it made `trim_amount = cache_offset - cache_hit_len` negative for any shared prefix longer than 256 tokens, so the trim never ran.

A Claude Code system prompt alone is ~24K tokens, so that is every real session: the cache kept the previous conversation's KV state and the new delta was appended on top of it at the wrong positions. The first session after a restart works (`_prompt_cache` is `None`, so the trim path is skipped) and every session after it degrades to empty output — exactly the 1/10 vs 6/6 measured in #46, and independent of KV quantization, which matches the `MLX_KV_BITS=0` result.

Introduced by 5812c7e, which fixed a genuine `AttributeError` on caches without `.offset` by switching to an unrelated attribute. Caches that do not expose `.offset` cannot be trimmed safely at all, so this falls through to a full prefill rather than trimming by a bogus amount.

Also addresses point 4 of the report: warn and drop the cache when a completion comes back empty after a cache hit, so the next request self-heals instead of failing silently.

Thanks to @KaoCSC for the measurement — the fresh-server control is what made this findable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)