### PR TITLE
fix: resolve the Claude Code CLI instead of hardcoding a path (#40)

### DIFF
--- a/launchers/Claude Agentico.command
+++ b/launchers/Claude Agentico.command
@@ -32,6 +32,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/claude-local-common.sh"
 
 CLAUDE_BIN="${CLAUDE_BIN:-$(command -v claude || echo $HOME/.local/bin/claude)}"
+require_claude_bin
 
 MLX_MODEL_DEFAULT="$(resolve_mlx_model \
   "$HOME/.cache/huggingface/hub/Qwen2.5-Coder-14B-Instruct-4bit" \

--- a/launchers/Claude Chat.command
+++ b/launchers/Claude Chat.command
@@ -34,6 +34,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/claude-local-common.sh"
 
 CLAUDE_BIN="${CLAUDE_BIN:-$(command -v claude || echo $HOME/.local/bin/claude)}"
+require_claude_bin
 
 MLX_MODEL_DEFAULT="$(resolve_mlx_model \
   "$HOME/.cache/huggingface/hub/Qwen2.5-Coder-14B-Instruct-4bit" \

--- a/launchers/Claude Local.command
+++ b/launchers/Claude Local.command
@@ -8,7 +8,8 @@
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/claude-local-common.sh"
 
-CLAUDE_BIN="${CLAUDE_BIN:-$HOME/.local/bin/claude}"
+CLAUDE_BIN="${CLAUDE_BIN:-$(command -v claude || echo $HOME/.local/bin/claude)}"
+require_claude_bin
 MODEL_NAME="${MLX_MODEL_LABEL:-Gemma 4 31B}"
 
 # Default model matches server.py's default so this launcher behaves like

--- a/launchers/Gemma 4 Code.command
+++ b/launchers/Gemma 4 Code.command
@@ -8,7 +8,8 @@
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/claude-local-common.sh"
 
-CLAUDE_BIN="${CLAUDE_BIN:-$HOME/.local/bin/claude}"
+CLAUDE_BIN="${CLAUDE_BIN:-$(command -v claude || echo $HOME/.local/bin/claude)}"
+require_claude_bin
 
 # Override with MLX_MODEL=<your-path-or-hf-id>. Prefers a local flat-folder
 # cache if you already downloaded the model via scripts/download-and-import.sh,

--- a/launchers/Llama 70B.command
+++ b/launchers/Llama 70B.command
@@ -8,7 +8,8 @@
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/claude-local-common.sh"
 
-CLAUDE_BIN="${CLAUDE_BIN:-$HOME/.local/bin/claude}"
+CLAUDE_BIN="${CLAUDE_BIN:-$(command -v claude || echo $HOME/.local/bin/claude)}"
+require_claude_bin
 
 # Default points at our own abliterated MLX upload:
 #   https://huggingface.co/divinetribe/Llama-3.3-70B-Instruct-abliterated-8bit-mlx

--- a/launchers/Narrative Gemma.command
+++ b/launchers/Narrative Gemma.command
@@ -14,7 +14,8 @@
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/claude-local-common.sh"
 
-CLAUDE_BIN="${CLAUDE_BIN:-$HOME/.local/bin/claude}"
+CLAUDE_BIN="${CLAUDE_BIN:-$(command -v claude || echo $HOME/.local/bin/claude)}"
+require_claude_bin
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)/NarrativeGemma"
 COMBINED_PROMPT="/tmp/narrative_gemma_combined_prompt.md"
 

--- a/launchers/lib/claude-local-common.sh
+++ b/launchers/lib/claude-local-common.sh
@@ -148,3 +148,41 @@ force_restart_mlx_server() {
     exit 1
   fi
 }
+
+# Resolve the Claude Code CLI. Launchers used to hardcode $HOME/.local/bin/claude,
+# which fails outright for anyone who installed it via npm, Homebrew, or the
+# official installer into a different prefix (issue #40). Check PATH first, then
+# the usual install locations, and fail with something actionable instead of
+# "No such file or directory".
+require_claude_bin() {
+  if [ -n "$CLAUDE_BIN" ] && [ -x "$CLAUDE_BIN" ]; then
+    return 0
+  fi
+  local c
+  for c in "$(command -v claude 2>/dev/null)" \
+           "$HOME/.local/bin/claude" \
+           "$HOME/.claude/local/claude" \
+           "/opt/homebrew/bin/claude" \
+           "/usr/local/bin/claude"; do
+    if [ -n "$c" ] && [ -x "$c" ]; then
+      CLAUDE_BIN="$c"
+      return 0
+    fi
+  done
+  echo ""
+  echo "  ERROR: Claude Code CLI not found."
+  echo ""
+  echo "  Looked on your PATH and in:"
+  echo "    \$HOME/.local/bin/claude"
+  echo "    \$HOME/.claude/local/claude"
+  echo "    /opt/homebrew/bin/claude"
+  echo "    /usr/local/bin/claude"
+  echo ""
+  echo "  Install it with:"
+  echo "    curl -fsSL https://claude.ai/install.sh | bash"
+  echo ""
+  echo "  Already installed somewhere else? Point this launcher at it:"
+  echo "    CLAUDE_BIN=/path/to/claude \"\$0\""
+  echo ""
+  exit 1
+}


### PR DESCRIPTION
Fixes #40.

`Claude Local`, `Gemma 4 Code`, `Llama 70B` and `Narrative Gemma` hardcoded `$HOME/.local/bin/claude`. Anyone who installed Claude Code via npm, Homebrew, or into a different prefix hit this with no clue what was wrong:

```
/Users/admin/Desktop/Claude Local.command: line 22: /Users/admin/.local/bin/claude: No such file or directory
```

`Claude Chat` and `Claude Agentico` already resolved via `command -v` — this brings the other four in line, and adds `require_claude_bin()` to the shared lib so a genuinely missing CLI produces something actionable rather than a bare ENOENT out of `exec`.

Resolution order: explicit `$CLAUDE_BIN` → `PATH` → `~/.local/bin` → `~/.claude/local` → `/opt/homebrew/bin` → `/usr/local/bin`.

Verified three ways in a scrubbed `env -i` shell:

- CLI absent everywhere → prints the install command plus the `CLAUDE_BIN=` override and exits before launching
- CLI on `PATH` at a non-default prefix → resolves to it
- explicit `CLAUDE_BIN=` → honoured even when nothing is on `PATH`

`bash -n` clean on all launchers and the lib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)